### PR TITLE
feishu: include claw_config.h for credential defaults

### DIFF
--- a/claw/services/im/feishu.c
+++ b/claw/services/im/feishu.c
@@ -15,6 +15,7 @@
  */
 
 #include "osal/claw_os.h"
+#include "claw_config.h"
 #include "claw/services/im/feishu.h"
 #include "claw/services/ai/ai_engine.h"
 #include "claw/tools/claw_tools.h"


### PR DESCRIPTION
feishu.c uses CONFIG_RTCLAW_FEISHU_APP_ID and
CONFIG_RTCLAW_FEISHU_APP_SECRET but never included claw_config.h where the #ifndef defaults are defined. This worked before because Kconfig provided them via sdkconfig.h, but after removing credentials from Kconfig the macros became undeclared.