### PR TITLE
docs: update architecture diagram and i18n Get Started link

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1234,13 +1234,10 @@ function toggleLang() {
     }
 })();
 
-/* ── GitHub Star Count ── */
+/* ── GitHub Star Count (always fetch, cache for instant display) ── */
 (function() {
     var cached = sessionStorage.getItem('rtclaw-stars');
-    if (cached !== null) {
-        updateStarBadges(cached);
-        return;
-    }
+    if (cached !== null) updateStarBadges(cached);
     fetch('https://api.github.com/repos/zevorn/rt-claw')
         .then(function(r) { return r.json(); })
         .then(function(data) {


### PR DESCRIPTION
## Summary

- Website architecture diagram updated to layered design (Application → Skills → Tools → Drivers → OSAL → RTOS → Hardware)
- Get Started button links to docs/en or docs/zh based on language
- README feature table and platform table simplified
- Chinese slogan updated: 让 AI 助手 再次廉价 → 让 AI 助理 触手可及
- Fix logo path and GitHub star count fetch

## Test plan

- [ ] Verify architecture diagram renders aligned in browser
- [ ] Toggle EN/中文, confirm Get Started links to correct doc
- [ ] Check README tables render correctly on GitHub

Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>