### PR TITLE
docs: rename feishu to im in architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ESP32-S3 WiFi support adapted from [MimiClaw](https://github.com/memovai/mimicla
 ```
 +--------------------------------------------------------------+
 |                     rt-claw Application                      |
-| gateway | net | swarm | ai_engine | shell | sched | feishu   |
+|    gateway | net | swarm | ai_engine | shell | sched | im    |
 +--------------------------------------------------------------+
 |                      skills (AI Skills)                      |
 |             (one skill composes multiple tools)              |

--- a/README_zh.md
+++ b/README_zh.md
@@ -53,7 +53,7 @@ ESP32-S3 WiFi 支持参考了 [MimiClaw](https://github.com/memovai/mimiclaw)。
 ```
 +--------------------------------------------------------------+
 |                     rt-claw Application                      |
-| gateway | net | swarm | ai_engine | shell | sched | feishu   |
+|    gateway | net | swarm | ai_engine | shell | sched | im    |
 +--------------------------------------------------------------+
 |                      skills (AI Skills)                      |
 |             (one skill composes multiple tools)              |

--- a/website/index.html
+++ b/website/index.html
@@ -725,7 +725,7 @@
         <p class="section-subtitle reveal" data-en="Clean layered design with OSAL bridging multiple RTOS platforms." data-zh="简洁的分层设计，通过 OSAL 桥接多个 RTOS 平台。">Clean layered design with OSAL bridging multiple RTOS platforms.</p>
         <div class="arch-diagram reveal">+--------------------------------------------------------------+
 |                     rt-claw Application                      |
-|  gateway | net | swarm | ai_engine | shell | sched | feishu  |
+|    gateway | net | swarm | ai_engine | shell | sched | im    |
 +--------------------------------------------------------------+
 |                      skills (AI Skills)                      |
 |             (one skill composes multiple tools)              |


### PR DESCRIPTION
## Summary

- Architecture diagram: `feishu` → `im` in Application layer
- Feishu is one IM backend; the layer represents the generic IM service
- Updated in README.md, README_zh.md, and website/index.html

Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>