### PR TITLE
website: add documentation center and rename feishu to im

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'website/**'
       - 'images/**'
+      - 'docs/**'
       - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
@@ -27,8 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Copy images to website
-        run: cp -r images/ website/img/
+      - name: Copy images and docs to website
+        run: |
+          cp -r images/ website/img/
+          cp -r docs/ website/docs/
 
       - name: Download ESP32-S3 firmware (if available)
         uses: dawidd6/action-download-artifact@v6

--- a/website/docs.html
+++ b/website/docs.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RT-Claw Documentation</title>
+    <meta name="description" content="RT-Claw documentation — getting started, usage, architecture, porting, tuning.">
+    <link rel="icon" type="image/png" href="img/icon.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+    <style>
+        *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg: #0f172a;
+            --bg-alt: #1e293b;
+            --bg-card: #1e293b;
+            --text: #f1f5f9;
+            --text-muted: #94a3b8;
+            --accent: #f59e0b;
+            --accent-light: #fbbf24;
+            --accent2: #06b6d4;
+            --accent3: #10b981;
+            --border: #334155;
+            --radius: 12px;
+            --font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            --mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+        }
+
+        html { scroll-behavior: smooth; }
+
+        body {
+            font-family: var(--font);
+            background: var(--bg);
+            color: var(--text);
+            line-height: 1.7;
+            overflow-x: hidden;
+        }
+
+        a { color: var(--accent); text-decoration: none; transition: color 0.2s; }
+        a:hover { color: var(--accent-light); }
+
+        /* Nav */
+        nav {
+            position: fixed; top: 0; width: 100%; z-index: 100;
+            background: rgba(15, 23, 42, 0.88);
+            backdrop-filter: blur(16px);
+            border-bottom: 1px solid var(--border);
+        }
+        .nav-inner {
+            max-width: 1200px; margin: 0 auto; padding: 0 2rem;
+            display: flex; align-items: center; justify-content: space-between;
+            height: 64px;
+        }
+        .nav-logo {
+            font-size: 1.2rem; font-weight: 700; color: var(--text);
+            display: flex; align-items: center; gap: 0.5rem;
+        }
+        .nav-logo img { height: 28px; }
+        .nav-links { display: flex; align-items: center; gap: 1.5rem; list-style: none; }
+        .nav-links a {
+            color: var(--text-muted); font-size: 0.88rem; font-weight: 500;
+            transition: color 0.2s;
+        }
+        .nav-links a:hover { color: var(--text); }
+        .nav-github {
+            color: var(--text-muted); display: flex; align-items: center; gap: 0.4rem;
+            transition: color 0.2s;
+        }
+        .nav-github:hover { color: var(--text); }
+        .lang-toggle {
+            display: inline-flex; align-items: center;
+            background: rgba(148, 163, 184, 0.12); border: 1px solid var(--border);
+            border-radius: 20px; padding: 0; overflow: hidden; font-size: 0.78rem;
+            font-weight: 600; cursor: pointer; user-select: none;
+        }
+        .lang-toggle span {
+            padding: 0.25rem 0.55rem; transition: background 0.2s, color 0.2s;
+            color: var(--text-muted);
+        }
+        .lang-toggle span.active { background: var(--accent); color: #fff; }
+        .nav-toggle {
+            display: none; background: none; border: none;
+            color: var(--text); font-size: 1.5rem; cursor: pointer;
+        }
+
+        /* Layout */
+        .docs-layout {
+            display: flex; min-height: 100vh; padding-top: 64px;
+        }
+
+        /* Sidebar */
+        .docs-sidebar {
+            width: 260px; min-width: 260px;
+            background: var(--bg-alt); border-right: 1px solid var(--border);
+            padding: 1.5rem 0; overflow-y: auto; position: sticky; top: 64px;
+            height: calc(100vh - 64px);
+        }
+        .docs-sidebar h3 {
+            font-size: 0.7rem; font-weight: 700; text-transform: uppercase;
+            letter-spacing: 0.08em; color: var(--text-muted);
+            padding: 0.5rem 1.5rem; margin-top: 0.5rem;
+        }
+        .docs-sidebar a {
+            display: block; padding: 0.5rem 1.5rem; font-size: 0.88rem;
+            color: var(--text-muted); border-left: 3px solid transparent;
+            transition: color 0.2s, border-color 0.2s, background 0.2s;
+        }
+        .docs-sidebar a:hover {
+            color: var(--text); background: rgba(245, 158, 11, 0.05);
+        }
+        .docs-sidebar a.active {
+            color: var(--accent); border-left-color: var(--accent);
+            background: rgba(245, 158, 11, 0.08);
+        }
+
+        /* Content */
+        .docs-content {
+            flex: 1; max-width: 860px; padding: 2.5rem 3rem; min-width: 0;
+        }
+
+        /* Markdown rendering */
+        .docs-content h1 {
+            font-size: 2rem; font-weight: 800; margin-bottom: 1rem;
+            padding-bottom: 0.75rem; border-bottom: 1px solid var(--border);
+        }
+        .docs-content h2 {
+            font-size: 1.4rem; font-weight: 700; margin: 2rem 0 0.75rem;
+            padding-bottom: 0.5rem; border-bottom: 1px solid var(--border);
+        }
+        .docs-content h3 { font-size: 1.1rem; font-weight: 600; margin: 1.5rem 0 0.5rem; }
+        .docs-content h4 { font-size: 0.95rem; font-weight: 600; margin: 1.2rem 0 0.4rem; }
+        .docs-content p { margin: 0.75rem 0; }
+        .docs-content ul, .docs-content ol { margin: 0.75rem 0; padding-left: 1.5rem; }
+        .docs-content li { margin: 0.3rem 0; }
+        .docs-content blockquote {
+            border-left: 3px solid var(--accent); margin: 1rem 0;
+            padding: 0.5rem 1rem; background: rgba(245, 158, 11, 0.06);
+            border-radius: 0 8px 8px 0; color: var(--text-muted);
+        }
+        .docs-content table {
+            width: 100%; border-collapse: collapse; margin: 1rem 0;
+            font-size: 0.88rem;
+        }
+        .docs-content th, .docs-content td {
+            padding: 0.6rem 0.8rem; border: 1px solid var(--border);
+            text-align: left;
+        }
+        .docs-content th { background: var(--bg-alt); font-weight: 600; }
+        .docs-content code {
+            font-family: var(--mono); font-size: 0.85em;
+            background: rgba(148, 163, 184, 0.12); padding: 0.15rem 0.4rem;
+            border-radius: 4px;
+        }
+        .docs-content pre {
+            background: #0c0c0c; border: 1px solid var(--border);
+            border-radius: 8px; padding: 1rem 1.2rem; margin: 1rem 0;
+            overflow-x: auto; line-height: 1.5;
+        }
+        .docs-content pre code {
+            background: none; padding: 0; font-size: 0.82rem;
+            color: #d4d4d4;
+        }
+        .docs-content img { max-width: 100%; border-radius: 8px; margin: 1rem 0; }
+        .docs-content hr {
+            border: none; border-top: 1px solid var(--border); margin: 2rem 0;
+        }
+        .docs-content strong { color: var(--text); }
+
+        /* Loading */
+        .docs-loading {
+            color: var(--text-muted); font-style: italic; padding: 3rem 0;
+        }
+
+        /* Mobile sidebar toggle */
+        .sidebar-toggle {
+            display: none; position: fixed; bottom: 1.5rem; right: 1.5rem;
+            z-index: 200; width: 48px; height: 48px;
+            background: var(--accent); color: #fff; border: none;
+            border-radius: 50%; font-size: 1.2rem; cursor: pointer;
+            box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+        }
+
+        @media (max-width: 768px) {
+            .nav-links { display: none; }
+            .nav-toggle { display: block; }
+            .docs-sidebar {
+                position: fixed; left: -280px; top: 64px; z-index: 150;
+                width: 280px; min-width: 280px;
+                transition: left 0.3s; box-shadow: 4px 0 20px rgba(0,0,0,0.3);
+            }
+            .docs-sidebar.open { left: 0; }
+            .sidebar-toggle { display: block; }
+            .docs-content { padding: 1.5rem 1rem; }
+        }
+    </style>
+</head>
+<body>
+
+<!-- Navigation -->
+<nav>
+    <div class="nav-inner">
+        <a href="index.html" class="nav-logo">
+            <img src="img/logo.png" alt="RT-Claw">
+            RT-Claw
+        </a>
+        <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Menu">&#9776;</button>
+        <ul class="nav-links">
+            <li><a href="index.html" data-en="Home" data-zh="首页">Home</a></li>
+            <li><a href="index.html#flash" data-en="Flash" data-zh="烧录">Flash</a></li>
+            <li>
+                <div class="lang-toggle" onclick="toggleLang()">
+                    <span id="lang-en" class="active">EN</span>
+                    <span id="lang-zh">中文</span>
+                </div>
+            </li>
+            <li><a href="https://github.com/zevorn/rt-claw" class="nav-github" target="_blank">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 21.795 24 17.295 24 12c0-6.63-5.37-12-12-12"/></svg>
+                GitHub
+            </a></li>
+        </ul>
+    </div>
+</nav>
+
+<div class="docs-layout">
+    <!-- Sidebar -->
+    <aside class="docs-sidebar" id="docs-sidebar">
+        <h3 data-en="Documentation" data-zh="文档中心">Documentation</h3>
+        <a href="?doc=getting-started" data-doc="getting-started" data-en="Getting Started" data-zh="快速开始">Getting Started</a>
+        <a href="?doc=usage" data-doc="usage" data-en="Usage Guide" data-zh="使用指南">Usage Guide</a>
+        <a href="?doc=architecture" data-doc="architecture" data-en="Architecture" data-zh="架构设计">Architecture</a>
+        <a href="?doc=porting" data-doc="porting" data-en="Porting & Extension" data-zh="移植与扩展">Porting & Extension</a>
+        <a href="?doc=tuning" data-doc="tuning" data-en="Tuning & Optimization" data-zh="裁剪与优化">Tuning & Optimization</a>
+        <h3 data-en="Contributing" data-zh="参与贡献">Contributing</h3>
+        <a href="?doc=coding-style" data-doc="coding-style" data-en="Coding Style" data-zh="编码风格">Coding Style</a>
+        <a href="?doc=contributing" data-doc="contributing" data-en="Contributing" data-zh="贡献指南">Contributing</a>
+    </aside>
+
+    <!-- Content -->
+    <main class="docs-content" id="docs-content">
+        <p class="docs-loading" data-en="Loading documentation..." data-zh="正在加载文档...">Loading documentation...</p>
+    </main>
+</div>
+
+<!-- Mobile sidebar toggle -->
+<button class="sidebar-toggle" onclick="document.getElementById('docs-sidebar').classList.toggle('open')">&#9776;</button>
+
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script>
+var currentLang = localStorage.getItem('lang') || 'en';
+var currentDoc = 'getting-started';
+
+function getDocParam() {
+    var params = new URLSearchParams(window.location.search);
+    return params.get('doc') || 'getting-started';
+}
+
+function loadDoc(name) {
+    currentDoc = name;
+    var content = document.getElementById('docs-content');
+    content.innerHTML = '<p class="docs-loading">' +
+        (currentLang === 'zh' ? '正在加载文档...' : 'Loading documentation...') + '</p>';
+
+    var path = 'docs/' + currentLang + '/' + name + '.md';
+    fetch(path)
+        .then(function(r) {
+            if (!r.ok) throw new Error(r.status);
+            return r.text();
+        })
+        .then(function(md) {
+            content.innerHTML = marked.parse(md);
+            window.scrollTo(0, 0);
+        })
+        .catch(function() {
+            content.innerHTML = '<p class="docs-loading">' +
+                (currentLang === 'zh' ? '文档未找到。' : 'Document not found.') + '</p>';
+        });
+
+    /* Update active link */
+    document.querySelectorAll('.docs-sidebar a[data-doc]').forEach(function(a) {
+        a.classList.toggle('active', a.getAttribute('data-doc') === name);
+    });
+
+    /* Update URL without reload */
+    history.replaceState(null, '', '?doc=' + name);
+}
+
+/* Sidebar link click */
+document.querySelectorAll('.docs-sidebar a[data-doc]').forEach(function(a) {
+    a.addEventListener('click', function(e) {
+        e.preventDefault();
+        loadDoc(this.getAttribute('data-doc'));
+        document.getElementById('docs-sidebar').classList.remove('open');
+    });
+});
+
+/* i18n */
+function switchLang(lang) {
+    currentLang = lang;
+    document.documentElement.lang = lang;
+    localStorage.setItem('lang', lang);
+
+    document.getElementById('lang-en').classList.toggle('active', lang === 'en');
+    document.getElementById('lang-zh').classList.toggle('active', lang === 'zh');
+
+    document.querySelectorAll('[data-en]').forEach(function(el) {
+        if (!el.getAttribute('data-doc')) {
+            el.textContent = el.getAttribute('data-' + lang);
+        }
+    });
+
+    /* Update sidebar link text */
+    document.querySelectorAll('.docs-sidebar a[data-doc]').forEach(function(el) {
+        el.textContent = el.getAttribute('data-' + lang);
+    });
+
+    /* Reload current doc in new language */
+    loadDoc(currentDoc);
+}
+
+function toggleLang() {
+    switchLang(currentLang === 'en' ? 'zh' : 'en');
+}
+
+/* Init */
+currentDoc = getDocParam();
+if (currentLang !== 'en') {
+    switchLang(currentLang);
+} else {
+    loadDoc(currentDoc);
+}
+</script>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -558,6 +558,7 @@
         </a>
         <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Menu">&#9776;</button>
         <ul class="nav-links">
+            <li><a href="docs.html" data-en="Docs" data-zh="文档">Docs</a></li>
             <li><a href="#features" data-en="Features" data-zh="特性">Features</a></li>
             <li><a href="#architecture" data-en="Architecture" data-zh="架构">Architecture</a></li>
             <li><a href="#platforms" data-en="Platforms" data-zh="平台">Platforms</a></li>


### PR DESCRIPTION
## Summary

- Add `website/docs.html`: documentation center with sidebar + marked.js markdown rendering
- Sidebar lists all docs (Getting Started, Usage, Architecture, Porting, Tuning, Coding Style, Contributing)
- i18n: EN/中文 toggle fetches doc in selected language from `docs/{en,zh}/`
- CI: copy `docs/` → `website/docs/`, trigger deploy on `docs/**` changes
- Add Docs link to index.html nav bar
- Architecture diagram: rename `feishu` → `im` (generic IM service layer)

## Test plan

- [ ] Open docs.html, verify all 7 docs load and render correctly
- [ ] Toggle EN/中文, confirm docs switch language
- [ ] Mobile: verify sidebar toggle works
- [ ] CI: verify docs/ gets copied to website/docs/

Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>