### PR TITLE
website: fix board dropdown not updating on platform change

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1011,7 +1011,7 @@ const BOARD_OPTIONS = {
     ],
 };
 
-function updateBoardOptions() {
+window.updateBoardOptions = function() {
     var platform = document.getElementById('flash-platform').value;
     var boardSelect = document.getElementById('flash-board');
     var boards = BOARD_OPTIONS[platform] || [];
@@ -1022,8 +1022,8 @@ function updateBoardOptions() {
         opt.textContent = b.label;
         boardSelect.appendChild(opt);
     });
-}
-updateBoardOptions();
+};
+window.updateBoardOptions();
 
 const flashBtn = document.getElementById('flash-btn');
 const flashEraseBtn = document.getElementById('flash-erase-btn');


### PR DESCRIPTION
## Summary

Fix `updateBoardOptions()` not reachable from HTML `onchange` attribute.
The function was defined inside `<script type="module">` (module scope)
but called from an inline handler in global scope. Attach to `window`.

## Test plan

- [ ] Change Platform dropdown, verify Board dropdown updates

Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>