### PR TITLE
website: auto-disconnect on unload and fix UTF-8 decoding

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1557,11 +1557,12 @@ async function serialConnect() {
 async function serialReadLoop() {
     while (serialPort && serialPort.readable && serialKeepReading) {
         serialReader = serialPort.readable.getReader();
+        var utf8Decoder = new TextDecoder('utf-8', { fatal: false });
         try {
             while (true) {
                 var result = await serialReader.read();
                 if (result.done) break;
-                serialAppendAnsi(new TextDecoder().decode(result.value));
+                serialAppendAnsi(utf8Decoder.decode(result.value, { stream: true }));
             }
         } catch (e) {
             if (serialKeepReading) {
@@ -1622,6 +1623,11 @@ function serialClear() {
         serialOutput.textContent = curLang3 === 'zh' ? '\u70B9\u51FB\u201C\u8FDE\u63A5\u201D\u6253\u5F00\u4E32\u53E3...' : 'Click "Connect" to open a serial port...';
     }
 }
+
+/* ── Release serial port on page unload ── */
+window.addEventListener('beforeunload', function() {
+    if (serialPort) serialDisconnect();
+});
 
 /* ── Expand (cover flash panel) ── */
 function serialExpand() {


### PR DESCRIPTION
## Summary

- Add `beforeunload` handler to release serial port on page refresh
- Reuse single `TextDecoder` with `stream: true` across read chunks to fix garbled Chinese/emoji from multi-byte UTF-8 splits

## Test plan

- [ ] Refresh page while serial connected, reconnect without error
- [ ] Send Chinese text and emoji through serial, verify no garbled output

Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>