### PR TITLE
ci: fix docs not deployed in build-firmware workflow

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -119,8 +119,10 @@ jobs:
           name: esp32s3-default-firmware
           path: website/firmware/esp32s3-default/
 
-      - name: Copy images to website
-        run: cp -r images/ website/img/
+      - name: Copy images and docs to website
+        run: |
+          cp -r images/ website/img/
+          cp -r docs/ website/docs/
 
       - uses: actions/configure-pages@v5
 


### PR DESCRIPTION
## Summary

The docs viewer shows "Document not found" because `build-firmware.yml`'s
deploy job deploys to GitHub Pages **without copying docs/**.  When it runs
after `deploy-pages.yml`, it overwrites the site and docs disappear.

Fix: add `cp -r docs/ website/docs/` to `build-firmware.yml` deploy step.

## Root cause

Two workflows deploy to the same GitHub Pages environment:
- `deploy-pages.yml`: copies images + docs ✓
- `build-firmware.yml`: copies images only ✗ ← this one overwrites without docs

Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>