### PR TITLE
website: fix serial expand height and input sending

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -476,7 +476,7 @@
         .serial-ctrl-btn:hover { border-color: var(--accent); color: var(--accent); }
         .serial-ctrl-btn.active { border-color: var(--accent3); color: var(--accent3); }
         .serial-output {
-            padding: 0.75rem 1rem; flex: 1; min-height: 200px; overflow-y: auto;
+            padding: 0.75rem 1rem; height: 360px; overflow-y: auto;
             font-family: var(--mono); font-size: 0.8rem; line-height: 1.5;
             color: #d4d4d4; word-break: break-all;
         }
@@ -500,6 +500,9 @@
         .serial-panel.expanded {
             position: absolute; top: 0; left: 0; right: 0; bottom: 0;
             z-index: 10; border-radius: var(--radius);
+        }
+        .serial-panel.expanded .serial-output {
+            height: auto; flex: 1;
         }
         .serial-msg-success { color: #4ade80; }
         .serial-msg-error { color: #f87171; }
@@ -1590,11 +1593,14 @@ async function serialDisconnect() {
 }
 
 async function serialSend() {
-    if (!serialWriter) return;
+    if (!serialWriter) {
+        serialLogMsg('[Not connected]\n', 'serial-msg-warning');
+        return;
+    }
     var text = serialInput.value;
     if (!text) return;
     try {
-        await serialWriter.write(new TextEncoder().encode(text + '\n'));
+        await serialWriter.write(new TextEncoder().encode(text + '\r\n'));
         serialInput.value = '';
     } catch (e) {
         serialLogMsg('\n[Send error] ' + e.message + '\n', 'serial-msg-error');


### PR DESCRIPTION
## Summary

Two serial terminal bugs:

1. **Expand height not restoring**: `serial-output` used `flex: 1` which
   grows unbounded in a flex container without fixed height. After
   expand/collapse the panel stayed oversized. Fixed to `height: 360px`,
   expanded mode overrides to `flex: 1` (works because panel has
   absolute positioning with defined bounds).

2. **Input not sending**: changed line ending from `\n` to `\r\n` for
   embedded terminal compatibility. Added "[Not connected]" warning
   when trying to send without an active connection.

## Test plan

- [ ] Connect serial, type message, press Enter or click Send
- [ ] Expand terminal, collapse, verify height returns to normal
- [ ] Try Send without connecting, verify warning appears

Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>