### PR TITLE
gateway: implement pipeline handler chain

### DIFF
--- a/claw/core/gateway.c
+++ b/claw/core/gateway.c
@@ -12,6 +12,29 @@
 
 #define TAG "gateway"
 
+/* --- Pipeline handlers --- */
+
+static struct gw_handler s_handlers[GW_MAX_HANDLERS];
+static int s_handler_count;
+
+int gateway_register_handler(const char *name, gw_handler_fn process)
+{
+    if (s_handler_count >= GW_MAX_HANDLERS) {
+        CLAW_LOGE(TAG, "handler registry full");
+        return CLAW_ERROR;
+    }
+    if (!name || !process) {
+        return CLAW_ERROR;
+    }
+
+    s_handlers[s_handler_count].name = name;
+    s_handlers[s_handler_count].process = process;
+    s_handler_count++;
+
+    CLAW_LOGI(TAG, "handler registered: %s", name);
+    return CLAW_OK;
+}
+
 /* --- Service registry --- */
 
 static struct gw_service_entry s_services[GW_MAX_SERVICES];
@@ -46,13 +69,30 @@ static struct gateway_stats s_stats;
 
 static void dispatch_msg(struct gateway_msg *msg)
 {
-    uint8_t bit = (uint8_t)(1 << msg->type);
-    int delivered = 0;
-
     s_stats.total++;
     if (msg->type < GW_MSG_TYPE_MAX) {
         s_stats.per_type[msg->type]++;
     }
+
+    /* Pipeline: run handlers in registration order */
+    for (int i = 0; i < s_handler_count; i++) {
+        int rc = s_handlers[i].process(msg);
+        if (rc > 0) {
+            s_stats.filtered++;
+            CLAW_LOGD(TAG, "msg type=%d consumed by %s",
+                      msg->type, s_handlers[i].name);
+            return;
+        }
+        if (rc < 0) {
+            CLAW_LOGW(TAG, "handler %s error %d on type=%d",
+                      s_handlers[i].name, rc, msg->type);
+            return;
+        }
+    }
+
+    /* Service dispatch: deliver to all matching consumers */
+    uint8_t bit = (uint8_t)(1 << msg->type);
+    int delivered = 0;
 
     for (int i = 0; i < s_service_count; i++) {
         if (s_services[i].type_mask & bit) {
@@ -95,6 +135,8 @@ static void gateway_thread_entry(void *param)
 
 int gateway_init(void)
 {
+    memset(s_handlers, 0, sizeof(s_handlers));
+    s_handler_count = 0;
     memset(s_services, 0, sizeof(s_services));
     memset(&s_stats, 0, sizeof(s_stats));
     s_service_count = 0;

--- a/include/claw/core/gateway.h
+++ b/include/claw/core/gateway.h
@@ -49,17 +49,27 @@ struct gw_service_entry {
     claw_mq_t inbox;            /* service's own message queue */
 };
 
+#define GW_MAX_HANDLERS     8
+
 /* Message statistics */
 struct gateway_stats {
     uint32_t total;                         /* total dispatched */
     uint32_t per_type[GW_MSG_TYPE_MAX];     /* per message type */
     uint32_t dropped;                       /* queue-full drops */
     uint32_t no_consumer;                   /* msgs with no match */
+    uint32_t filtered;                      /* consumed by pipeline */
 };
 
 int gateway_init(void);
 int gateway_send(struct gateway_msg *msg);
 void gateway_get_stats(struct gateway_stats *out);
+
+/**
+ * Register a pipeline handler. Handlers run in registration order
+ * before service dispatch. A handler returning 1 consumes the
+ * message (stops the chain); returning 0 passes it to the next.
+ */
+int gateway_register_handler(const char *name, gw_handler_fn process);
 
 /**
  * Register a service to receive messages matching type_mask.

--- a/tests/unit/test_gateway.c
+++ b/tests/unit/test_gateway.c
@@ -50,6 +50,52 @@ static void test_gateway_register_overflow(void)
     TEST_ASSERT(ret != CLAW_OK);
 }
 
+/* Pass-through handler: always returns 0 */
+static int handler_passthrough(struct gateway_msg *msg)
+{
+    (void)msg;
+    return 0;
+}
+
+/* Consumer handler: returns 1 to consume the message */
+static int handler_consume(struct gateway_msg *msg)
+{
+    (void)msg;
+    return 1;
+}
+
+static void test_handler_register(void)
+{
+    gateway_init();
+
+    TEST_ASSERT_EQ(
+        gateway_register_handler("pass", handler_passthrough), CLAW_OK);
+    TEST_ASSERT_EQ(
+        gateway_register_handler("consume", handler_consume), CLAW_OK);
+}
+
+static void test_handler_register_overflow(void)
+{
+    gateway_init();
+
+    for (int i = 0; i < GW_MAX_HANDLERS; i++) {
+        TEST_ASSERT_EQ(
+            gateway_register_handler("h", handler_passthrough), CLAW_OK);
+    }
+
+    TEST_ASSERT(
+        gateway_register_handler("over", handler_passthrough) != CLAW_OK);
+}
+
+static void test_pipeline_stats_filtered(void)
+{
+    gateway_init();
+
+    struct gateway_stats st;
+    gateway_get_stats(&st);
+    TEST_ASSERT_EQ(st.filtered, 0);
+}
+
 int test_gateway_suite(void)
 {
     printf("=== test_gateway ===\n");
@@ -59,6 +105,9 @@ int test_gateway_suite(void)
     RUN_TEST(test_gateway_register_service);
     RUN_TEST(test_gateway_stats_init);
     RUN_TEST(test_gateway_register_overflow);
+    RUN_TEST(test_handler_register);
+    RUN_TEST(test_handler_register_overflow);
+    RUN_TEST(test_pipeline_stats_filtered);
 
     TEST_END();
 }


### PR DESCRIPTION
## Summary

- Wire up the `gw_handler` pipeline declared in `gateway.h` but never implemented
- `gateway_register_handler(name, fn)` adds handlers to a static chain (max 8)
- `dispatch_msg()` runs handlers in registration order before service dispatch
- Handler returns: 0 = pass, 1 = consumed (stop), <0 = error (stop + log)
- New `gateway_stats.filtered` counter tracks messages consumed by pipeline

Memory cost: ~64 bytes (8 x 8B handler slots).

Enables message filtering, transformation, and rate limiting as pre-dispatch hooks without touching the service dispatch logic.

## Test plan

- [x] `make test-unit` — 25/25 passed (3 new gateway handler tests)
- [x] `scripts/check-patch.sh --staged` — 0 errors, 0 warnings