### PR TITLE
claw: add project-level Claude Code skills for dev workflows

### DIFF
--- a/.claude/skills/build-test/SKILL.md
+++ b/.claude/skills/build-test/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: build-test
+description: Build and test rt-claw on QEMU or real hardware. Use when user says "build", "compile", "run QEMU", "test", "burn/flash firmware", or specifies a platform target.
+disable-model-invocation: true
+user-invocable: true
+argument-hint: "[platform] [--gdb] [--graphics]"
+---
+
+# Build and Test RT-Claw
+
+Build the project for a specified platform and run it on QEMU or flash to real hardware.
+
+## Arguments
+
+$ARGUMENTS
+
+Supported platforms:
+- `esp32c3-qemu` (default)
+- `esp32c3-devkit`
+- `esp32c3-xiaozhi-xmini`
+- `esp32s3-qemu`
+- `esp32s3`
+- `vexpress-a9-qemu`
+
+Options:
+- `--gdb`: Enable GDB debug mode (port 1234)
+- `--graphics`: Enable LCD display window (ESP32 QEMU only)
+
+If no platform specified, auto-detect from current branch name or recent changes.
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Changed files: !`git diff --name-only HEAD`
+- Staged files: !`git diff --name-only --cached`
+
+## Workflow
+
+### Step 1: Determine target platform
+
+If `$ARGUMENTS` specifies a platform, use it directly.
+
+Otherwise, infer from context:
+1. Check branch name for platform hints (e.g., `esp32c3`, `esp32s3`, `vexpress`)
+2. Check changed files for platform-specific paths (e.g., `platform/esp32c3/`, `osal/rtthread/`)
+3. Default to `esp32c3-qemu` if ambiguous
+
+### Step 2: Run style check
+
+```bash
+scripts/check-patch.sh --staged
+```
+
+If there are style violations, report them but do NOT block the build.
+
+### Step 3: Build
+
+Run the appropriate build command:
+
+| Platform | Build Command |
+|----------|--------------|
+| esp32c3-qemu | `make build-esp32c3-qemu` |
+| esp32c3-devkit | `make build-esp32c3-devkit` |
+| esp32c3-xiaozhi-xmini | `make build-esp32c3-xiaozhi-xmini` |
+| esp32s3-qemu | `make build-esp32s3-qemu` |
+| esp32s3 | `make build-esp32s3` |
+| vexpress-a9-qemu | `make vexpress-a9-qemu` |
+
+If the build fails:
+1. Show the first error message
+2. Analyze the root cause (missing header, link error, type mismatch, etc.)
+3. Suggest a fix
+4. Do NOT auto-fix unless the user confirms
+
+### Step 4: Run (QEMU platforms only)
+
+For QEMU platforms, launch the emulator:
+
+| Platform | Run Command |
+|----------|------------|
+| esp32c3-qemu | `make run-esp32c3-qemu` |
+| esp32s3-qemu | `make run-esp32s3-qemu` |
+| vexpress-a9-qemu | `make run-vexpress-a9-qemu` |
+
+Add `GDB=1` if `--gdb` was specified.
+Add `GRAPHICS=1` if `--graphics` was specified.
+
+For real hardware platforms:
+- `esp32c3-devkit` / `esp32c3-xiaozhi-xmini`: `make flash-esp32c3-<board>`
+- `esp32s3`: `make flash-esp32s3`
+
+Inform the user to connect the board and monitor serial output.
+
+### Step 5: Report results
+
+Summarize:
+- Build status (success/failure)
+- Binary size (if available)
+- QEMU boot status (if applicable)
+- Any warnings worth noting

--- a/.claude/skills/diagnose/SKILL.md
+++ b/.claude/skills/diagnose/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: diagnose
+description: Analyze error logs from QEMU output, serial monitor, CI pipelines, or build failures. This skill should automatically activate when the user pastes terminal output containing error messages, stack traces, build failures, boot logs, or CI job output.
+user-invocable: true
+argument-hint: "[paste error log or describe the issue]"
+---
+
+# Diagnose RT-Claw Errors
+
+Analyze error output from various sources and suggest fixes.
+
+## Arguments
+
+$ARGUMENTS
+
+The user typically pastes raw log output directly. Accept any format.
+
+## Context
+
+- Current platform config: !`cat build/*/meson/meson-info/intro-buildoptions.json 2>/dev/null | head -5 || echo "no build dir"`
+- Recent changes: !`git diff --stat HEAD~3..HEAD 2>/dev/null`
+
+## Common Error Patterns in RT-Claw
+
+### Build Errors
+| Pattern | Likely Cause | Fix |
+|---------|-------------|-----|
+| `undefined reference to claw_*` | Missing OSAL impl or Meson source list | Check meson.build includes the .c file |
+| `implicit declaration of function` | Missing `#include` | Add the header to include order |
+| `redefinition of macro` | `claw_config.h` vs `claw_gen_config.h` conflict | Check macro guard in claw_config.h |
+| `multiple definition of` | Header has function body without `static inline` | Move to .c or add `static inline` |
+
+### Runtime Errors (QEMU / Real Hardware)
+| Pattern | Likely Cause | Fix |
+|---------|-------------|-----|
+| `DHCP timeout` / `dhcp_fine_tmr` | QEMU network not bridged | Check QEMU -nic option, use OpenCores Ethernet for ESP32 |
+| `DNS resolution failed` | No DNS in QEMU or wrong network config | Use api-proxy.py for HTTP->HTTPS |
+| `TLS handshake failed` / `esp_tls` | ESP32 QEMU lacks TLS offload | Route through api-proxy.py |
+| `HTTP 503` | API endpoint down or rate limited | Check API URL and key validity |
+| `Stack overflow` / `pxCurrentTCB` | Task stack too small | Increase stack size in task creation |
+| `Data Abort` / `Prefetch Abort` | NULL pointer or bad memory access | Use GDB: `make run-*-qemu GDB=1` |
+| `guru meditation error` | ESP-IDF crash (watchdog, stack, alloc) | Check backtrace, increase stack |
+| `Task watchdog got triggered` | Task blocked too long | Check mutex deadlocks, reduce blocking calls |
+
+### CI Errors
+| Pattern | Likely Cause | Fix |
+|---------|-------------|-----|
+| `QEMU boot test failed` | AI boot test needs network (unavailable in CI) | Guard with `CONFIG_RTCLAW_AI_BOOT_TEST` |
+| `check-patch.sh failed` | Code style violation | Run `scripts/check-patch.sh --staged` locally |
+| `DCO check failed` | Missing `Signed-off-by` | Use `git commit -s` |
+
+### Network/IM Errors
+| Pattern | Likely Cause | Fix |
+|---------|-------------|-----|
+| Feishu `no connection detected` | Wrong WebSocket endpoint or token expired | Verify app_id/app_secret, check endpoint URL |
+| Telegram `HTTP 503` | Bot token invalid or Telegram API down | Verify token with `getMe` API call |
+| `connection reset by peer` | TLS version mismatch or proxy issue | Check api-proxy.py is running |
+
+## Workflow
+
+### Step 1: Classify the error
+
+Determine the error category:
+- **Build error**: compilation or linking failure
+- **Runtime crash**: abort, stack overflow, watchdog, data abort
+- **Network error**: DNS, TLS, HTTP, WebSocket
+- **CI failure**: automated test or check failure
+- **Boot failure**: system doesn't reach shell prompt
+
+### Step 2: Extract key information
+
+From the log output, identify:
+- Error message and error code
+- File and line number (if available)
+- Call stack / backtrace
+- Platform and configuration context
+
+### Step 3: Root cause analysis
+
+Cross-reference with:
+1. The common error patterns table above
+2. Recent code changes (`git diff`)
+3. Platform-specific constraints (QEMU limitations, memory limits)
+4. Known issues in the project
+
+### Step 4: Suggest fix
+
+Provide:
+1. The most likely root cause
+2. A concrete fix (code change, config change, or command)
+3. How to verify the fix worked
+4. If uncertain, list 2-3 possible causes ranked by probability
+
+### Step 5: Offer to implement
+
+Ask the user if they want the fix applied immediately.
+Do NOT auto-apply — the user decides.

--- a/.claude/skills/new-module/SKILL.md
+++ b/.claude/skills/new-module/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: new-module
+description: Scaffold a new claw service, driver, or tool module. Use when user wants to "add a new service", "create a driver", "implement a new module", or "add tool use support".
+disable-model-invocation: true
+user-invocable: true
+argument-hint: "<type> <name> [description]"
+---
+
+# Create New RT-Claw Module
+
+Scaffold a new module following the project's established architecture patterns.
+
+## Arguments
+
+$ARGUMENTS
+
+Format: `<type> <name> [description]`
+
+- `type`: One of `service`, `driver`, `tool`
+- `name`: Module name in snake_case (e.g., `bluetooth`, `audio_tts`, `weather`)
+- `description`: Optional one-line description
+
+## Context
+
+- Existing services: !`ls claw/services/`
+- Existing tools: !`ls claw/tools/*.c 2>/dev/null`
+- Existing drivers: !`ls -d drivers/*/ 2>/dev/null`
+- Meson options: !`head -60 meson_options.txt`
+- Init registration: !`grep -n 'service_start\|register' claw/claw_init.c | head -20`
+
+## Module Architecture Reference
+
+### Service Module Pattern (claw/services/<subsystem>/)
+
+Based on existing services (ai, net, swarm, im):
+
+1. **Header** (`claw/services/<name>/<name>.h`):
+   - Header guard: `CLAW_SERVICES_<NAME>_H`
+   - Include `claw_os.h` first
+   - Public API: `<name>_init()`, `<name>_start()`, `<name>_stop()`
+   - SPDX license header
+
+2. **Source** (`claw/services/<name>/<name>.c`):
+   - Include order: own header -> `claw_os.h` -> system headers -> project headers
+   - Static internal state (no global mutable state)
+   - Thread-safe design (mutex for shared state)
+   - Task creation via `claw_task_create()`
+
+3. **Meson integration** (`claw/services/<name>/meson.build`):
+   - Conditional compilation via feature option
+   - Add source files to `claw_sources`
+
+4. **Registration** (`claw/claw_init.c`):
+   - `#include` the header (guarded by feature macro)
+   - Call `<name>_init()` in `claw_init()`
+
+5. **Configuration** (`meson_options.txt`):
+   - Add `option('enable_<name>', type: 'boolean', value: false, description: '...')`
+
+### Driver Module Pattern (drivers/<subsystem>/<vendor>/)
+
+Based on existing drivers (net/espressif, audio/espressif, display/espressif):
+
+1. **Header** (`include/drivers/<subsystem>/<vendor>/<name>.h`)
+2. **Source** (`drivers/<subsystem>/<vendor>/<name>.c`)
+3. Thin wrapper around vendor SDK, exposing clean API
+4. No business logic — hardware abstraction only
+
+### Tool Module Pattern (claw/tools/)
+
+Based on existing Tool Use framework:
+
+1. **Source** (`claw/tools/tool_<name>.c`)
+2. Register via `CLAW_TOOL_REGISTER()` macro
+3. Declare capabilities with `SWARM_CAP_*` flags
+4. Implement `tool_<name>_execute()` callback
+
+## Workflow
+
+### Step 1: Validate arguments
+
+Parse `$ARGUMENTS` into type, name, and optional description.
+Verify no existing module conflicts with the name.
+
+### Step 2: Create files
+
+Generate the module files following the patterns above.
+Apply project code style:
+- C99, 4-space indent, ~80 char lines
+- `snake_case` functions, `CamelCase` structs, `UPPER_CASE` constants
+- `/* C style comments only */`
+- SPDX MIT license header
+
+### Step 3: Wire up build system
+
+- Add `meson.build` in the module directory
+- Add feature option to `meson_options.txt`
+- Include the meson.build from parent directory
+
+### Step 4: Register in init
+
+Add the module initialization call to `claw/claw_init.c`, guarded by the feature macro.
+
+### Step 5: Verify build
+
+Run `meson compile -C build/esp32c3-qemu/meson` to verify the new module compiles.
+
+### Step 6: Summary
+
+Show the created files and suggest next steps:
+- Implement the actual business logic
+- Add shell commands if interactive
+- Add QEMU test coverage
+- Update documentation

--- a/.claude/skills/platform-port/SKILL.md
+++ b/.claude/skills/platform-port/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: platform-port
+description: Guide porting RT-Claw to a new hardware platform or RTOS. Use when user wants to "add a new platform", "port to a new board", "support new hardware", or "add a new RTOS backend".
+disable-model-invocation: true
+user-invocable: true
+argument-hint: "<platform-name> [rtos: freertos|rtthread]"
+---
+
+# Port RT-Claw to a New Platform
+
+Step-by-step guide for adding a new hardware platform or board variant.
+
+## Arguments
+
+$ARGUMENTS
+
+Format: `<platform-name> [rtos]`
+- `platform-name`: e.g., `esp32c6`, `stm32h7`, `rpi-pico`
+- `rtos`: `freertos` (default) or `rtthread`
+
+## Context
+
+- Existing platforms: !`ls -d platform/*/`
+- OSAL backends: !`ls osal/`
+- Board abstraction: !`head -40 include/claw_board.h 2>/dev/null`
+- Cross-file examples: !`ls platform/*/cross.ini 2>/dev/null; ls scripts/gen-*-cross.py 2>/dev/null`
+
+## Platform Architecture Reference
+
+```
+platform/<name>/                # Platform root
+├── boards/                     # Board variants (if multiple)
+│   ├── qemu/                   # QEMU virtual board
+│   │   ├── sdkconfig.defaults
+│   │   └── partitions.csv
+│   └── <board>/                # Real hardware board
+│       ├── sdkconfig.defaults
+│       └── partitions.csv
+├── main/                       # Platform entry point
+│   └── main.c                  # Calls claw_init()
+├── CMakeLists.txt              # Native build system (ESP-IDF: idf.py)
+├── SConscript                  # RT-Thread: SCons build
+└── cross.ini                   # Meson cross-compilation file
+```
+
+## Porting Checklist
+
+### Phase 1: Build Infrastructure
+
+- [ ] Create `platform/<name>/` directory structure
+- [ ] Create Meson cross-file (`cross.ini`) or generator script (`scripts/gen-<name>-cross.py`)
+- [ ] Add Makefile targets: `build-<name>`, `run-<name>-qemu` (if QEMU available)
+- [ ] Verify `meson compile` produces `libclaw.a` and `libosal.a`
+
+### Phase 2: OSAL Backend
+
+If using an existing RTOS with existing OSAL backend (FreeRTOS or RT-Thread):
+- [ ] Verify OSAL backend compiles for the new architecture
+- [ ] Check timer tick resolution matches expectations
+- [ ] Test mutex, semaphore, task creation
+
+If adding a new RTOS:
+- [ ] Create `osal/<rtos>/claw_os_<rtos>.c` implementing all APIs in `include/osal/claw_os.h`
+- [ ] Create `osal/<rtos>/claw_net_<rtos>.c` implementing `include/osal/claw_net.h`
+- [ ] Add RTOS vendor code to `vendor/os/<rtos>/`
+- [ ] Add `osal_backend` option value to `meson_options.txt`
+
+### Phase 3: Board Abstraction
+
+- [ ] Implement `board_early_init()` in platform main
+- [ ] Implement `board_platform_commands()` for platform-specific shell commands
+- [ ] Call `claw_init()` from platform main after board init
+- [ ] Configure network: WiFi driver or Ethernet (QEMU: OpenCores/LAN9118)
+
+### Phase 4: Driver Integration
+
+- [ ] Identify available hardware peripherals
+- [ ] Create drivers under `drivers/<subsystem>/<vendor>/` if new hardware
+- [ ] Reuse existing drivers where possible (e.g., `drivers/net/espressif/` for ESP32 variants)
+- [ ] Add driver headers to `include/drivers/<subsystem>/<vendor>/`
+
+### Phase 5: QEMU Support (if available)
+
+- [ ] Configure QEMU machine type and arguments
+- [ ] Add QEMU run script or Makefile target
+- [ ] Verify network connectivity in QEMU (OpenCores Ethernet or user-mode networking)
+- [ ] Test AI API connectivity via `scripts/api-proxy.py`
+
+### Phase 6: Verification
+
+- [ ] Build passes: `make build-<name>`
+- [ ] Style check passes: `scripts/check-patch.sh`
+- [ ] QEMU boots to shell prompt (if QEMU available)
+- [ ] AI chat works via terminal
+- [ ] All existing platforms still build (no regressions)
+
+## Workflow
+
+### Step 1: Analyze the target
+
+Identify:
+- CPU architecture (RISC-V, ARM Cortex-M/A, Xtensa)
+- RTOS choice and SDK toolchain
+- Available QEMU machine emulation
+- Network capability (WiFi, Ethernet, cellular)
+- Memory constraints (Flash, RAM, PSRAM)
+
+### Step 2: Create scaffold
+
+Generate the platform directory structure following the reference above.
+Use the closest existing platform as a template:
+- ESP32-S3 for new Espressif chips
+- ESP32-C3 for new RISC-V platforms
+- vexpress-a9 for new RT-Thread platforms
+
+### Step 3: Implement incrementally
+
+Follow the phases above in order. Verify each phase builds before moving to the next.
+
+### Step 4: Update documentation
+
+- Add platform to `CLAUDE.md` Key Paths table
+- Add build/run commands to `docs/*/usage.md`
+- Update README Quick Start if this is a primary platform
+- Add porting notes to `docs/*/porting.md`

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: sync-docs
+description: Synchronize documentation after code changes. Use when user says "update docs", "sync documentation", "update README", "update architecture diagram", or after a significant feature/refactoring is complete.
+disable-model-invocation: true
+user-invocable: true
+argument-hint: "[scope: all | readme | arch | usage | api]"
+---
+
+# Synchronize RT-Claw Documentation
+
+Update documentation to reflect current codebase state. Always maintains bilingual EN/ZH parity.
+
+## Arguments
+
+$ARGUMENTS
+
+Scope options:
+- `all` (default): Full documentation sync
+- `readme`: README.md and README_zh.md only
+- `arch`: Architecture diagrams and docs/*/architecture.md
+- `usage`: Build/run/flash usage guides
+- `api`: API reference and header documentation
+
+## Context
+
+- Recent changes: !`git log --oneline -10`
+- Changed files since last tag: !`git diff --name-only $(git describe --tags --abbrev=0 2>/dev/null || echo HEAD~20)..HEAD 2>/dev/null | head -40`
+- Current docs structure: !`find docs/ -name '*.md' -type f 2>/dev/null | sort`
+- README sections: !`grep '^##' README.md 2>/dev/null`
+
+## Documentation Structure
+
+```
+README.md              (EN, primary)
+README_zh.md           (ZH, mirror)
+docs/
+├── en/
+│   ├── architecture.md
+│   ├── coding-style.md
+│   ├── usage.md
+│   ├── porting.md
+│   ├── tool-extension.md
+│   └── tuning.md
+└── zh/
+    ├── architecture.md
+    ├── coding-style.md
+    ├── usage.md
+    ├── porting.md
+    ├── tool-extension.md
+    └── tuning.md
+```
+
+## Workflow
+
+### Step 1: Analyze what changed
+
+Read the git diff to determine which subsystems were affected:
+- `claw/services/*` → update architecture.md service descriptions
+- `claw/tools/*` → update tool-extension.md
+- `platform/*` → update usage.md build/run/flash sections
+- `include/*` → update API references
+- `osal/*` → update architecture.md OSAL section
+- `drivers/*` → update architecture.md driver section
+- `Makefile` / `meson_options.txt` → update usage.md build commands
+- `claw_config.h` → update usage.md configuration section
+
+### Step 2: Update affected documents
+
+For each affected doc:
+
+1. Read the current EN version
+2. Identify sections that need updating
+3. Update EN version with accurate, current information
+4. Update ZH version to maintain parity (direct translation, not summary)
+
+Rules:
+- Keep ASCII architecture diagrams aligned (monospace box drawing)
+- Feature tables must reflect actual implementation status
+- Build/run commands must match current Makefile targets
+- Configuration examples must match current option names and env vars
+- Do NOT add content that describes unimplemented features
+
+### Step 3: Update README if needed
+
+If the scope includes README or the changes are significant:
+- Update feature status table
+- Update architecture diagram if subsystems changed
+- Update Quick Start if build/run workflow changed
+- Verify all internal links (`docs/en/...`, `docs/zh/...`) are valid
+
+### Step 4: Verify consistency
+
+- Check EN and ZH versions have matching section structure
+- Check all referenced file paths exist
+- Check all referenced Makefile targets exist
+- Check code examples compile (if practical)
+
+### Step 5: Summary
+
+List all files updated and what was changed in each.

--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,5 @@ sd.bin
 platform/*/cross.ini
 
 # Claude Code
-.claude/
+.claude/*
+!.claude/skills/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,18 @@ No unit test framework yet. Verify changes by:
 2. `scripts/check-patch.sh --staged` passes
 3. QEMU boot test: `make run-vexpress-a9-qemu` or `make run-esp32c3-qemu` or `make run-esp32s3-qemu`
 
+## Skills (Claude Code Slash Commands)
+
+Project-level skills in `.claude/skills/`, invoked via `/command-name`:
+
+| Command | Description |
+|---------|-------------|
+| `/build-test [platform]` | Build and run on QEMU or flash to real hardware |
+| `/new-module <type> <name>` | Scaffold a new service, driver, or tool module |
+| `/diagnose` | Analyze pasted error logs (build, runtime, CI, network) |
+| `/sync-docs [scope]` | Update EN/ZH docs after code changes |
+| `/platform-port <name>` | Guide porting to a new hardware platform |
+
 ## Key Paths
 
 | Path | Purpose |


### PR DESCRIPTION
## Summary

- Add 5 project-level Claude Code slash commands (`.claude/skills/`) extracted from 25 development conversations
- `/build-test`: build and run on QEMU or flash to real hardware
- `/new-module`: scaffold service, driver, or tool modules
- `/diagnose`: analyze build, runtime, CI, and network error logs (auto-triggers on pasted logs)
- `/sync-docs`: synchronize EN/ZH documentation after code changes
- `/platform-port`: guide porting to new hardware platforms
- Update `.gitignore` to track `.claude/skills/` while keeping other `.claude/` contents ignored
- Add skills reference table to `CLAUDE.md`

## Test plan

- [ ] Verify `/build-test esp32c3-qemu` triggers correct build flow
- [ ] Verify `/new-module service test_svc` scaffolds correct file structure
- [ ] Verify `/diagnose` activates when pasting QEMU error logs
- [ ] Verify `/sync-docs` detects changed subsystems from git diff
- [ ] Verify `.claude/settings.json` remains gitignored