### PR TITLE
build: fix header guards, config prefix, and QEMU path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,8 +215,9 @@ _c3-build:
 #
 ESP_S3_DIR := platform/esp32s3
 
-# Espressif QEMU xtensa binary (not in PATH by default after export.sh)
-QEMU_XTENSA := $(HOME)/.espressif/tools/qemu-xtensa/esp_develop_9.0.0_20240606/qemu/bin/qemu-system-xtensa
+# Espressif QEMU xtensa binary (not in PATH by default after export.sh).
+# Dynamically find the installed version to avoid hardcoding version strings.
+QEMU_XTENSA := $(shell find $(HOME)/.espressif/tools/qemu-xtensa -name qemu-system-xtensa -type f 2>/dev/null | head -1)
 
 # Default aliases
 .PHONY: build-esp32s3 esp32s3-qemu

--- a/include/drivers/audio/espressif/es8311_audio.h
+++ b/include/drivers/audio/espressif/es8311_audio.h
@@ -6,8 +6,8 @@
  * Supports playback (speaker) and capture (microphone).
  */
 
-#ifndef DRIVERS_AUDIO_ES8311_AUDIO_H
-#define DRIVERS_AUDIO_ES8311_AUDIO_H
+#ifndef CLAW_DRIVERS_AUDIO_ESPRESSIF_ES8311_AUDIO_H
+#define CLAW_DRIVERS_AUDIO_ESPRESSIF_ES8311_AUDIO_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -50,4 +50,4 @@ void es8311_audio_write(const int16_t *data, size_t samples);
  */
 int es8311_audio_play_sound(const char *name);
 
-#endif /* DRIVERS_AUDIO_ES8311_AUDIO_H */
+#endif /* CLAW_DRIVERS_AUDIO_ESPRESSIF_ES8311_AUDIO_H */

--- a/include/drivers/display/espressif/ssd1306_oled.h
+++ b/include/drivers/display/espressif/ssd1306_oled.h
@@ -6,8 +6,8 @@
  * Uses ESP-IDF esp_lcd + I2C.  No LVGL dependency.
  */
 
-#ifndef DRIVERS_DISPLAY_SSD1306_OLED_H
-#define DRIVERS_DISPLAY_SSD1306_OLED_H
+#ifndef CLAW_DRIVERS_DISPLAY_ESPRESSIF_SSD1306_OLED_H
+#define CLAW_DRIVERS_DISPLAY_ESPRESSIF_SSD1306_OLED_H
 
 #include <stdint.h>
 
@@ -54,4 +54,4 @@ void ssd1306_progress_bar(int row, int percent);
 /** Set pixel at (x, y). Call ssd1306_flush() to update display. */
 void ssd1306_set_pixel(int x, int y, int on);
 
-#endif /* DRIVERS_DISPLAY_SSD1306_OLED_H */
+#endif /* CLAW_DRIVERS_DISPLAY_ESPRESSIF_SSD1306_OLED_H */

--- a/platform/esp32c3/boards/qemu/sdkconfig.defaults
+++ b/platform/esp32c3/boards/qemu/sdkconfig.defaults
@@ -47,5 +47,4 @@ CONFIG_COMPILER_OPTIMIZATION_SIZE=y
 CONFIG_NEWLIB_STDIN_LINE_ENDING_LF=y
 
 # Feishu (Lark) Integration
-# CONFIG_CLAW_FEISHU_ENABLE=y
-# Set App ID and Secret via: idf.py menuconfig -> rt-claw -> Feishu
+# CONFIG_RTCLAW_FEISHU_ENABLE=y


### PR DESCRIPTION
## Summary

- **Header guards**: rename `DRIVERS_AUDIO_ES8311_AUDIO_H` → `CLAW_DRIVERS_AUDIO_ESPRESSIF_ES8311_AUDIO_H` and `DRIVERS_DISPLAY_SSD1306_OLED_H` → `CLAW_DRIVERS_DISPLAY_ESPRESSIF_SSD1306_OLED_H` to match the project `CLAW_<PATH>_<NAME>_H` convention
- **Config prefix**: fix stale `CONFIG_CLAW_FEISHU_ENABLE` comment → `CONFIG_RTCLAW_FEISHU_ENABLE` in ESP32-C3 qemu sdkconfig.defaults
- **Makefile**: replace hardcoded QEMU xtensa path (`esp_develop_9.0.0_20240606`) with dynamic `find(1)` lookup so it survives Espressif tool updates

## Test plan

- [x] ESP32-C3 QEMU build passes
- [x] vexpress-a9 QEMU build passes
- [x] `scripts/check-patch.sh` — 0 errors