### PR TITLE
osal: fix include order in net and kv implementations

### DIFF
--- a/osal/freertos/claw_kv_freertos.c
+++ b/osal/freertos/claw_kv_freertos.c
@@ -5,8 +5,8 @@
  * OSAL KV storage — ESP-IDF NVS Flash backend.
  */
 
-#include "osal/claw_kv.h"
 #include "osal/claw_os.h"
+#include "osal/claw_kv.h"
 
 #ifdef CLAW_PLATFORM_ESP_IDF
 

--- a/osal/freertos/claw_net_freertos.c
+++ b/osal/freertos/claw_net_freertos.c
@@ -5,8 +5,8 @@
  * OSAL network — ESP-IDF implementation using esp_http_client.
  */
 
-#include "osal/claw_net.h"
 #include "osal/claw_os.h"
+#include "osal/claw_net.h"
 
 #include "esp_http_client.h"
 #include "esp_crt_bundle.h"

--- a/osal/rtthread/claw_kv_rtthread.c
+++ b/osal/rtthread/claw_kv_rtthread.c
@@ -7,8 +7,8 @@
  * can be added later without changing callers.
  */
 
-#include "osal/claw_kv.h"
 #include "osal/claw_os.h"
+#include "osal/claw_kv.h"
 
 #include <string.h>
 #include <stdio.h>

--- a/osal/rtthread/claw_net_rtthread.c
+++ b/osal/rtthread/claw_net_rtthread.c
@@ -6,8 +6,8 @@
  * HTTP only (no TLS). For HTTPS use an HTTP proxy with TLS termination.
  */
 
-#include "osal/claw_net.h"
 #include "osal/claw_os.h"
+#include "osal/claw_net.h"
 
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
## Summary

Fix include order in 4 OSAL implementation files: `claw_os.h` must be the first project include per coding style, but `claw_net.h`/`claw_kv.h` were placed before it.

Files fixed:
- `osal/freertos/claw_net_freertos.c`
- `osal/freertos/claw_kv_freertos.c`
- `osal/rtthread/claw_net_rtthread.c`
- `osal/rtthread/claw_kv_rtthread.c`

## Test plan

- [x] ESP32-C3 QEMU build passes
- [x] vexpress-a9 QEMU build passes
- [x] `scripts/check-patch.sh` — 0 errors on all 4 files