### PR TITLE
fix: serial input bar height stretching with flash panel

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -451,6 +451,7 @@
         .serial-titlebar {
             display: flex; align-items: center; justify-content: space-between;
             padding: 0.6rem 1rem; background: #1a1a2e; border-bottom: 1px solid var(--border);
+            flex-shrink: 0;
         }
         .serial-titlebar span {
             font-family: var(--mono); font-size: 0.82rem; color: var(--text-muted);
@@ -477,13 +478,14 @@
         .serial-ctrl-btn:hover { border-color: var(--accent); color: var(--accent); }
         .serial-ctrl-btn.active { border-color: var(--accent3); color: var(--accent3); }
         .serial-output {
-            padding: 0.75rem 1rem; height: 360px; max-height: 360px;
+            padding: 0.75rem 1rem; min-height: 360px; flex: 1;
             overflow-y: auto; font-family: var(--mono); font-size: 0.8rem;
             line-height: 1.5; color: #d4d4d4; word-break: break-all;
         }
         .serial-output > div { white-space: pre-wrap; min-height: 1.2em; }
         .serial-input-bar {
             display: flex; border-top: 1px solid var(--border);
+            flex-shrink: 0;
         }
         .serial-input-bar input {
             flex: 1; background: transparent; border: none; padding: 0.6rem 1rem;
@@ -503,7 +505,7 @@
             z-index: 10; border-radius: var(--radius);
         }
         .serial-panel.expanded .serial-output {
-            height: auto; max-height: none; flex: 1;
+            min-height: 0; flex: 1;
         }
         .serial-msg-success { color: #4ade80; }
         .serial-msg-error { color: #f87171; }


### PR DESCRIPTION
## Summary

The grid layout (`align-items: stretch`) makes both panels equal height. The serial output area had a fixed `height: 360px` that didn't expand, causing flex to push extra space into the input bar, making it unnaturally tall.

## Fix

- `serial-output`: `height: 360px` → `min-height: 360px; flex: 1` (fills available space)
- `serial-titlebar`: add `flex-shrink: 0` (stays fixed)
- `serial-input-bar`: add `flex-shrink: 0` (stays fixed)
- Expanded mode: `min-height: 0` override (no minimum when fullscreen)

## Test plan

- [x] Serial panel matches flash panel height without stretching input bar
- [ ] Expand button still works correctly
- [ ] Mobile layout (stacked) unaffected