### PR TITLE
fix: serial panel height grows with output instead of scrolling

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -447,6 +447,7 @@
             background: #0c0c0c; border: 1px solid var(--border);
             border-radius: var(--radius); overflow: hidden;
             display: flex; flex-direction: column;
+            min-height: 480px;
         }
         .serial-titlebar {
             display: flex; align-items: center; justify-content: space-between;
@@ -478,7 +479,7 @@
         .serial-ctrl-btn:hover { border-color: var(--accent); color: var(--accent); }
         .serial-ctrl-btn.active { border-color: var(--accent3); color: var(--accent3); }
         .serial-output {
-            padding: 0.75rem 1rem; min-height: 360px; flex: 1;
+            padding: 0.75rem 1rem; height: 0; flex: 1;
             overflow-y: auto; font-family: var(--mono); font-size: 0.8rem;
             line-height: 1.5; color: #d4d4d4; word-break: break-all;
         }


### PR DESCRIPTION
## Problem

Serial output area used `min-height: 360px; flex: 1` — when content exceeded the minimum, the flex container expanded, pushing the entire page layout taller instead of scrolling.

## Fix

- `serial-output`: `min-height: 360px` → `height: 0` (flex:1 allocates all height from grid, content scrolls via overflow-y:auto)
- `serial-panel`: add `min-height: 480px` as a floor when flash panel is shorter

## Test plan

- [ ] Serial panel stays fixed height when output accumulates
- [ ] Output scrolls within the panel
- [ ] Panel still matches flash panel height via grid stretch
- [ ] Expand mode still works
- [ ] Mobile stacked layout unaffected