### PR TITLE
fix: serial panel height grows with output instead of scrolling

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -353,7 +353,7 @@
         }
         .flash-layout {
             display: grid; grid-template-columns: 1fr 1fr; gap: 2.5rem;
-            align-items: stretch; position: relative;
+            align-items: start; position: relative;
         }
         .flash-panel {
             background: var(--bg-card); border: 1px solid var(--border);


### PR DESCRIPTION
## Problem

Grid `align-items: stretch` makes row height equal to the tallest child. When serial output content exceeds the flash panel height, the serial-panel grows unbounded instead of scrolling.

## Root Cause

`height: 0; flex: 1` on serial-output only constrains to parent height. But grid stretch means the parent (serial-panel) height = max(flash-panel, serial-panel content), creating a circular dependency where content drives the container height.

## Fix

`align-items: stretch` → `align-items: start` — each panel has independent height. Serial panel uses `min-height: 480px` as its fixed floor. Serial output scrolls within this fixed container.