### PR TITLE
fix: serial panel still grows — use fixed height instead of min-height

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -447,7 +447,7 @@
             background: #0c0c0c; border: 1px solid var(--border);
             border-radius: var(--radius); overflow: hidden;
             display: flex; flex-direction: column;
-            min-height: 480px;
+            height: 480px;
         }
         .serial-titlebar {
             display: flex; align-items: center; justify-content: space-between;


### PR DESCRIPTION
\`min-height: 480px\` only sets a floor. The panel still grows unbounded when serial output content exceeds it.

Fix: \`min-height\` → \`height: 480px\`. Combined with \`overflow: hidden\` on the panel and \`height: 0; flex: 1; overflow-y: auto\` on serial-output, content scrolls within the fixed container.