### PR TITLE
fix: serial panel aligns with flash panel without growing

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -353,7 +353,7 @@
         }
         .flash-layout {
             display: grid; grid-template-columns: 1fr 1fr; gap: 2.5rem;
-            align-items: start; position: relative;
+            align-items: stretch; position: relative;
         }
         .flash-panel {
             background: var(--bg-card); border: 1px solid var(--border);
@@ -447,7 +447,7 @@
             background: #0c0c0c; border: 1px solid var(--border);
             border-radius: var(--radius); overflow: hidden;
             display: flex; flex-direction: column;
-            height: 480px;
+            min-height: 0;
         }
         .serial-titlebar {
             display: flex; align-items: center; justify-content: space-between;
@@ -506,7 +506,7 @@
             z-index: 10; border-radius: var(--radius);
         }
         .serial-panel.expanded .serial-output {
-            min-height: 0; flex: 1;
+            flex: 1;
         }
         .serial-msg-success { color: #4ade80; }
         .serial-msg-error { color: #f87171; }


### PR DESCRIPTION
## Problem

Serial panel either didn't match flash panel height, or grew unbounded with content.

## Root Cause

Grid items have implicit `min-height: auto` which prevents them from being smaller than their content. When serial output grows, it pushes the grid row taller.

## Fix

- `align-items: stretch` — both panels equal height (determined by flash panel)
- `serial-panel`: **`min-height: 0`** — overrides the implicit `min-height: auto`, so the panel respects the grid row height instead of being pushed by content
- `serial-output`: `height: 0; flex: 1; overflow-y: auto` — fills remaining space, scrolls
- `serial-titlebar` + `serial-input-bar`: `flex-shrink: 0` — fixed height