### PR TITLE
fix: add missing Feishu/Telegram/heartbeat Kconfig entries for ESP32

### DIFF
--- a/platform/esp32c3/components/rt_claw/Kconfig
+++ b/platform/esp32c3/components/rt_claw/Kconfig
@@ -72,6 +72,27 @@ menu "rt-claw Configuration"
             help
                 Predefined prompt templates (draw, monitor, greet).
 
+        config RTCLAW_FEISHU_ENABLE
+            bool "Enable Feishu (Lark) IM integration"
+            default n
+            help
+                WebSocket long connection to Feishu. Receives messages
+                and replies via AI engine. No public IP needed.
+
+        config RTCLAW_TELEGRAM_ENABLE
+            bool "Enable Telegram Bot integration"
+            default n
+            help
+                HTTP long-polling Telegram Bot. Receives messages and
+                replies via AI engine. No public IP needed.
+
+        config RTCLAW_HEARTBEAT_ENABLE
+            bool "Enable periodic AI heartbeat"
+            default n
+            depends on RTCLAW_SCHED_ENABLE
+            help
+                Periodic LLM health check with device status reporting.
+
         config RTCLAW_OTA_ENABLE
             bool "Enable OTA firmware update"
             default n

--- a/platform/esp32s3/components/rt_claw/Kconfig
+++ b/platform/esp32s3/components/rt_claw/Kconfig
@@ -65,6 +65,27 @@ menu "rt-claw Configuration"
             help
                 Predefined prompt templates (draw, monitor, greet).
 
+        config RTCLAW_FEISHU_ENABLE
+            bool "Enable Feishu (Lark) IM integration"
+            default n
+            help
+                WebSocket long connection to Feishu. Receives messages
+                and replies via AI engine. No public IP needed.
+
+        config RTCLAW_TELEGRAM_ENABLE
+            bool "Enable Telegram Bot integration"
+            default n
+            help
+                HTTP long-polling Telegram Bot. Receives messages and
+                replies via AI engine. No public IP needed.
+
+        config RTCLAW_HEARTBEAT_ENABLE
+            bool "Enable periodic AI heartbeat"
+            default n
+            depends on RTCLAW_SCHED_ENABLE
+            help
+                Periodic LLM health check with device status reporting.
+
         config RTCLAW_OTA_ENABLE
             bool "Enable OTA firmware update"
             default n


### PR DESCRIPTION
## Problem

`CONFIG_RTCLAW_FEISHU_ENABLE`, `CONFIG_RTCLAW_TELEGRAM_ENABLE`, and `CONFIG_RTCLAW_HEARTBEAT_ENABLE` were used in C code but never declared in ESP32 Kconfig. Setting them in `sdkconfig.defaults` was silently ignored.

## Fix

Add all three to both `platform/esp32c3/components/rt_claw/Kconfig` and `platform/esp32s3/components/rt_claw/Kconfig`:
- `RTCLAW_FEISHU_ENABLE` — Feishu (Lark) WebSocket IM
- `RTCLAW_TELEGRAM_ENABLE` — Telegram Bot long-polling
- `RTCLAW_HEARTBEAT_ENABLE` — periodic AI health check (depends on sched)