### PR TITLE
platform: fix FreeRTOS scheduler on Zynq-A9 QEMU

### DIFF
--- a/platform/zynq-a9/FreeRTOSConfig.h
+++ b/platform/zynq-a9/FreeRTOSConfig.h
@@ -21,7 +21,7 @@
 #define configUSE_TICKLESS_IDLE                      0
 #define configCPU_CLOCK_HZ                          100000000UL
 #define configTICK_RATE_HZ                          1000
-#define configMAX_PRIORITIES                        8
+#define configMAX_PRIORITIES                        32
 #define configMINIMAL_STACK_SIZE                     256
 #define configMAX_TASK_NAME_LEN                     16
 #define configIDLE_SHOULD_YIELD                     1

--- a/platform/zynq-a9/FreeRTOS_asm_vectors.S
+++ b/platform/zynq-a9/FreeRTOS_asm_vectors.S
@@ -78,7 +78,7 @@
 .extern FreeRTOS_IRQ_Handler
 .extern FreeRTOS_SWI_Handler
 
-.section .freertos_vectors
+.section .freertos_vectors, "ax"
 _freertos_vector_table:
 	B	  _boot
 	B	  FreeRTOS_Undefined

--- a/platform/zynq-a9/link.ld
+++ b/platform/zynq-a9/link.ld
@@ -33,13 +33,14 @@ SECTIONS
         *(.boot)
     } > DDR
 
-    .freertos_vectors : {
+    /* 32-byte aligned for ARM VBAR requirement */
+    .freertos_vectors : ALIGN(32) {
         KEEP(*(.freertos_vectors))
         KEEP(*(.vectors))
     } > DDR
 
     /* Executable code */
-    .text : {
+    .text : ALIGN(4) {
         *(.text)
         *(.text.*)
         *(.gnu.linkonce.t.*)

--- a/platform/zynq-a9/startup.S
+++ b/platform/zynq-a9/startup.S
@@ -39,6 +39,14 @@ _reset:
     /* Disable interrupts */
     cpsid   if
 
+    /* Enable VFP/NEON (CP10 + CP11 full access) */
+    mrc p15, 0, r0, c1, c0, 2
+    orr r0, r0, #(0xF << 20)
+    mcr p15, 0, r0, c1, c0, 2
+    isb
+    mov r0, #(1 << 30)          /* FPEXC.EN */
+    vmsr fpexc, r0
+
     /* Set VBAR to FreeRTOS vector table */
     ldr r0, =_freertos_vector_table
     mcr p15, 0, r0, c12, c0, 0
@@ -64,9 +72,9 @@ _reset:
     cps #0x1b
     ldr sp, =__undef_stack
 
-    /* Switch to System mode (shared with User) */
-    cps #0x1f
-    ldr sp, =__stack
+    /* Switch to Supervisor mode — FreeRTOS ARM_CA9 port
+     * expects to start the scheduler from SVC mode. */
+    cps #0x13
 
     /* Clear BSS */
     ldr r0, =__bss_start


### PR DESCRIPTION
## Summary

Fix three issues that prevented FreeRTOS from scheduling tasks on the Zynq-A9 QEMU platform. After this fix, `claw_init()` runs to completion with all services initialized.

## Root causes

1. **Vector table overlap** — `.freertos_vectors` section lacked `"ax"` flags, so the linker assigned it the same VMA as `.text`. The IRQ vector at `VBAR+0x18` pointed to `Xil_In32` instead of `FreeRTOS_IRQ_Handler`

2. **VFP not enabled** — `vPortRestoreTaskContext` uses `VPOP {d0-d15}` / `VPOP {d16-d31}` to restore FPU context (`configUSE_TASK_FPU_SUPPORT=2`), but CP10/CP11 coprocessor access and FPEXC.EN were never set. This caused an Undefined Instruction exception on the first context switch

3. **Priority overflow** — `configMAX_PRIORITIES` was 8 but `CLAW_GW_THREAD_PRIO` and `CLAW_AI_WORKER_PRIO` are 15, triggering `configASSERT(uxPriority < configMAX_PRIORITIES)` in `xTaskCreate()`

## Changes

| File | Fix |
|------|-----|
| `FreeRTOS_asm_vectors.S` | Add `"ax"` flags to `.freertos_vectors` section |
| `link.ld` | Add `ALIGN(32)` to `.freertos_vectors` (ARM VBAR requirement) |
| `startup.S` | Enable VFP (CPACR CP10/CP11 + FPEXC.EN), run main in SVC mode |
| `FreeRTOSConfig.h` | `configMAX_PRIORITIES` 8 → 32 |

## Boot output after fix

```
rt-claw: Zynq-A9 QEMU (FreeRTOS) - Real-Time Claw

  +-----------------------------------------+
  |          rt-claw v0.1.0                 |
  |  Real-Time Claw / Swarm Intelligence    |
  +-----------------------------------------+

[I/init] init: gateway
[I/gateway] started / initialized
[I/init] init: sched
[I/init] init: swarm
[I/init] init: net
[I/init] init: tools
[I/init] init: ai_engine
[I/ai] engine ready (model: claude-sonnet-4-6, tools: 1)
[I/init] init: ai_skill
[I/init] start: swarm
```

## Test plan

- [x] `make run-zynq-a9-qemu` — full boot, all services initialize
- [x] `make test-smoke-zynq` — boot banner test passes
- [ ] Verify ESP32 and vexpress-a9 builds unaffected