### PR TITLE
platform: disable feishu in ESP32-S3 QEMU to fix CI

### DIFF
--- a/platform/esp32s3/boards/qemu/sdkconfig.defaults
+++ b/platform/esp32s3/boards/qemu/sdkconfig.defaults
@@ -37,5 +37,4 @@ CONFIG_RTCLAW_TOOL_NET=y
 # CONFIG_MBEDTLS_HARDWARE_SHA is not set
 
 # ---- Feishu (Lark) ----
-CONFIG_RTCLAW_FEISHU_ENABLE=y
-# Set App ID and Secret via: idf.py menuconfig -> rt-claw -> Feishu
+# CONFIG_RTCLAW_FEISHU_ENABLE=y


### PR DESCRIPTION
## Summary
- ESP32-S3 QEMU `sdkconfig.defaults` had `CONFIG_RTCLAW_FEISHU_ENABLE=y`, but CI has no valid feishu credentials
- This caused two problems:
  1. Feishu token refresh loop spamming `token response missing tenant_access_token` every 10s
  2. AI boot test thread conditionally compiled out (TLS memory guard in `claw_init.c:80-81`), so `[boot] AI>` never appears → `test_ai_boot_response` times out after 360s
- Fix: disable feishu for S3 QEMU, matching C3 QEMU configuration

## Test plan
- [ ] `online (esp32s3-qemu)` CI job passes
- [ ] `online (esp32c3-qemu)` CI job still passes (no change)