### PR TITLE
docs: add Zynq-A9 FreeRTOS+TCP platform documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ make build-esp32c3-qemu                # ESP32-C3 QEMU (default)
 make build-esp32c3-xiaozhi-xmini             # ESP32-C3 xiaozhi-xmini 16MB board
 make build-esp32c3-devkit              # ESP32-C3 generic 4MB devkit
 make vexpress-a9-qemu                  # Meson + SCons → build/vexpress-a9-qemu/
+make build-zynq-a9-qemu               # Meson full firmware → build/zynq-a9-qemu/
 make build-esp32s3-qemu                # Meson + idf.py (requires ESP-IDF)
 make esp32s3                           # Meson + idf.py (real hardware)
 
@@ -60,6 +61,10 @@ Meson generates `claw_gen_config.h` in the build directory with the resolved val
 # QEMU vexpress-a9 (RT-Thread)
 make run-vexpress-a9-qemu              # build + launch QEMU
 make run-vexpress-a9-qemu GDB=1       # debug mode (GDB port 1234)
+
+# Zynq-A9 QEMU (FreeRTOS + FreeRTOS+TCP)
+make run-zynq-a9-qemu                 # build + launch QEMU (Cadence GEM network)
+make run-zynq-a9-qemu GDB=1          # debug mode (GDB port 1234)
 
 # ESP32-C3 (board = qemu | devkit | xiaozhi-xmini)
 make run-esp32c3-qemu                 # build + launch QEMU simulator
@@ -132,11 +137,23 @@ scripts/install-hooks.sh
 
 ## Testing
 
-No unit test framework yet. Verify changes by:
+```bash
+# Unit tests (cross-compiled, QEMU semihosting)
+make test-unit                         # vexpress-a9 (RT-Thread)
+make test-unit-zynq                    # zynq-a9 (FreeRTOS)
+
+# Functional tests (Python unittest, QEMU boot/shell)
+make test-smoke-esp32c3                # ESP32-C3 smoke tests
+make test-smoke-esp32s3                # ESP32-S3 smoke tests
+make test-smoke-vexpress               # vexpress-a9 boot test
+make test-smoke-zynq                   # zynq-a9 boot test
+```
+
+Verify changes by:
 
 1. Build passes on at least one platform
 2. `scripts/check-patch.sh --staged` passes
-3. QEMU boot test: `make run-vexpress-a9-qemu` or `make run-esp32c3-qemu` or `make run-esp32s3-qemu`
+3. QEMU boot test: `make run-vexpress-a9-qemu` or `make run-esp32c3-qemu` or `make run-zynq-a9-qemu`
 
 ## Skills (Claude Code Slash Commands)
 
@@ -181,7 +198,11 @@ Project-level skills in `.claude/skills/`, invoked via `/command-name`:
 | `platform/esp32c3/boards/` | Board-specific configs (qemu, devkit, xiaozhi-xmini) |
 | `platform/esp32s3/` | ESP32-S3 unified ESP-IDF project (all boards) |
 | `platform/esp32s3/boards/` | Board-specific configs (qemu, default) |
+| `platform/zynq-a9/` | Zynq-A9 QEMU (FreeRTOS + FreeRTOS+TCP, Cadence GEM) |
+| `platform/zynq-a9/drivers/` | Patched Zynq GEM NetworkInterface (ISR/PHY fixes) |
 | `platform/vexpress-a9/` | RT-Thread BSP + Meson cross-file |
+| `vendor/bsp/xilinx/` | Xilinx standalone BSP subset (GIC, Timer, EMAC PS) |
+| `vendor/lib/freertos-plus-tcp/` | FreeRTOS+TCP networking stack (submodule) |
 | `scripts/gen-esp32c3-cross.py` | Generate ESP32-C3 Meson cross-file |
 | `scripts/gen-esp32s3-cross.py` | Generate ESP32-S3 Meson cross-file |
 | `scripts/api-proxy.py` | HTTP→HTTPS proxy for QEMU without TLS |

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ ESP32-S3 WiFi support adapted from [MimiClaw](https://github.com/memovai/mimicla
 | WiFi | ES8311 | SSD1306 | serial | LCD framebuffer           |
 +--------------------------------------------------------------+
 |                  osal/claw_os.h (OSAL API)                   |
-+-------------------+------------------------------------------+
-| FreeRTOS (IDF)    |                RT-Thread                 |
-+-------------------+------------------------------------------+
-| ESP32-C3 / S3     |             QEMU vexpress-a9             |
-+-------------------+------------------------------------------+
++-------------------+-----------------------+------------------+
+| FreeRTOS (IDF)    | FreeRTOS (standalone) |    RT-Thread     |
++-------------------+-----------------------+------------------+
+| ESP32-C3 / S3     | QEMU Zynq-A9 (GEM)    | QEMU vexpress-a9 |
++-------------------+-----------------------+------------------+
 ```
 
 ## Supported Platforms
@@ -78,6 +78,7 @@ ESP32-S3 WiFi support adapted from [MimiClaw](https://github.com/memovai/mimicla
 |----------|--------|------|-------|--------|
 | ESP32-C3 | QEMU, xiaozhi-xmini, generic devkit | ESP-IDF + FreeRTOS | Meson + CMake | Verified |
 | ESP32-S3 | QEMU, real hardware | ESP-IDF + FreeRTOS | Meson + CMake | Verified |
+| Zynq-A9 | QEMU | FreeRTOS + FreeRTOS+TCP | Meson (full firmware) | Verified |
 | vexpress-a9 | QEMU | RT-Thread | Meson + SCons | Verified |
 
 ## Quick Start

--- a/docs/en/porting.md
+++ b/docs/en/porting.md
@@ -112,7 +112,41 @@ meson compile -C build/<name>-<board>/meson
 | Pattern | Example | Key Files |
 |---------|---------|-----------|
 | ESP-IDF (FreeRTOS) | `platform/esp32c3/` | CMakeLists.txt, components/rt_claw/, boards/ |
+| Standalone FreeRTOS | `platform/zynq-a9/` | meson.build (full firmware), FreeRTOSConfig.h, startup.S |
 | RT-Thread (SCons) | `platform/vexpress-a9/` | SConstruct, rtconfig.py, cross.ini |
+
+### Standalone FreeRTOS Pattern (Zynq-A9 Example)
+
+When porting to a non-ESP-IDF FreeRTOS platform, the Zynq-A9 port demonstrates
+the "full Meson build" pattern where Meson compiles everything (kernel + BSP +
+OSAL + claw) into a single ELF:
+
+```
+platform/zynq-a9/
+├── startup.S               # Minimal ARM boot (VFP, VBAR, stacks)
+├── FreeRTOS_asm_vectors.S   # IRQ/SWI vector table
+├── FreeRTOSConfig.h         # FreeRTOS kernel configuration
+├── FreeRTOSIPConfig.h       # FreeRTOS+TCP network configuration
+├── main.c                   # GIC + Timer init, FreeRTOS+TCP init, claw_init()
+├── syscalls.c               # Newlib stubs (UART printf, sbrk, BSP stubs)
+├── link.ld                  # Linker script
+├── cross.ini                # Meson cross-file (osal='freertos', platform='zynq-a9')
+├── meson.build              # Compiles BSP + FreeRTOS + FreeRTOS+TCP + rtclaw → ELF
+├── drivers/
+│   └── NetworkInterface.c   # Patched Zynq GEM driver (QEMU workarounds)
+└── boards/qemu/
+    └── board.c              # Board abstraction (empty for QEMU)
+```
+
+Key differences from ESP-IDF pattern:
+
+- **No external build system** — Meson handles everything
+- **`platform` meson option** — set `platform = 'zynq-a9'` in cross.ini to
+  select `CLAW_PLATFORM_FREERTOS` (vs `CLAW_PLATFORM_ESP_IDF`)
+- **BSP in vendor/** — hardware drivers (GIC, Timer, EMAC) in `vendor/bsp/xilinx/`
+- **FreeRTOS+TCP** — standalone TCP/IP stack in `vendor/lib/freertos-plus-tcp/`
+- **claw_net uses FreeRTOS+TCP sockets** — `FreeRTOS_socket/connect/send/recv`
+  instead of ESP-IDF `esp_http_client` or POSIX sockets
 
 ## Adding a New Tool
 

--- a/docs/zh/porting.md
+++ b/docs/zh/porting.md
@@ -110,7 +110,40 @@ meson compile -C build/<name>-<board>/meson
 | 模式 | 示例 | 关键文件 |
 |------|------|----------|
 | ESP-IDF (FreeRTOS) | `platform/esp32c3/` | CMakeLists.txt, components/rt_claw/, boards/ |
+| 独立 FreeRTOS | `platform/zynq-a9/` | meson.build（完整固件）、FreeRTOSConfig.h、startup.S |
 | RT-Thread (SCons) | `platform/vexpress-a9/` | SConstruct, rtconfig.py, cross.ini |
+
+### 独立 FreeRTOS 模式（Zynq-A9 示例）
+
+当移植到非 ESP-IDF 的 FreeRTOS 平台时，Zynq-A9 展示了"完整 Meson 构建"模式——
+Meson 编译所有内容（内核 + BSP + OSAL + claw）生成单个 ELF 文件：
+
+```
+platform/zynq-a9/
+├── startup.S               # 最小 ARM 启动代码（VFP、VBAR、栈设置）
+├── FreeRTOS_asm_vectors.S   # IRQ/SWI 向量表
+├── FreeRTOSConfig.h         # FreeRTOS 内核配置
+├── FreeRTOSIPConfig.h       # FreeRTOS+TCP 网络配置
+├── main.c                   # GIC + Timer 初始化、FreeRTOS+TCP 初始化、claw_init()
+├── syscalls.c               # Newlib 桩函数（UART printf、sbrk、BSP 桩）
+├── link.ld                  # 链接脚本
+├── cross.ini                # Meson 交叉编译文件（osal='freertos', platform='zynq-a9'）
+├── meson.build              # 编译 BSP + FreeRTOS + FreeRTOS+TCP + rtclaw → ELF
+├── drivers/
+│   └── NetworkInterface.c   # 修补的 Zynq GEM 网络驱动（QEMU 适配）
+└── boards/qemu/
+    └── board.c              # 板级抽象（QEMU 为空）
+```
+
+与 ESP-IDF 模式的关键差异：
+
+- **无外部构建系统** — Meson 处理所有编译和链接
+- **`platform` meson 选项** — 在 cross.ini 中设置 `platform = 'zynq-a9'`
+  以选择 `CLAW_PLATFORM_FREERTOS`（而非 `CLAW_PLATFORM_ESP_IDF`）
+- **BSP 在 vendor/ 中** — 硬件驱动（GIC、Timer、EMAC）位于 `vendor/bsp/xilinx/`
+- **FreeRTOS+TCP** — 独立 TCP/IP 栈位于 `vendor/lib/freertos-plus-tcp/`
+- **claw_net 使用 FreeRTOS+TCP socket** — `FreeRTOS_socket/connect/send/recv`
+  替代 ESP-IDF 的 `esp_http_client` 或 POSIX socket
 
 ## 添加新工具
 

--- a/website/index.html
+++ b/website/index.html
@@ -313,6 +313,7 @@
         .platform-card:nth-child(1)::before { background: linear-gradient(90deg, var(--accent), var(--accent2)); }
         .platform-card:nth-child(2)::before { background: linear-gradient(90deg, var(--accent2), var(--accent3)); }
         .platform-card:nth-child(3)::before { background: linear-gradient(90deg, var(--accent3), var(--accent)); }
+        .platform-card:nth-child(4)::before { background: linear-gradient(90deg, #8b5cf6, var(--accent2)); }
         .platform-card h3 { font-size: 1.15rem; margin-bottom: 0.75rem; font-weight: 600; }
         .platform-tag {
             display: inline-block; padding: 0.2rem 0.6rem; border-radius: 4px;
@@ -752,11 +753,11 @@
 |      WiFi | ES8311 | SSD1306 | serial | LCD framebuffer      |
 +--------------------------------------------------------------+
 |                  osal/claw_os.h  (OSAL API)                  |
-+-------------------+------------------------------------------+
-| FreeRTOS (IDF)    |                RT-Thread                 |
-+-------------------+------------------------------------------+
-| ESP32-C3 / S3     |             QEMU vexpress-a9             |
-+-------------------+------------------------------------------+</div>
++-------------------+-----------------------+------------------+
+| FreeRTOS (IDF)    | FreeRTOS (standalone) |    RT-Thread     |
++-------------------+-----------------------+------------------+
+| ESP32-C3 / S3     | QEMU Zynq-A9 (GEM)    | QEMU vexpress-a9 |
++-------------------+-----------------------+------------------+</div>
     </div>
 </section>
 
@@ -822,6 +823,21 @@
                     <li data-en="No hardware needed" data-zh="无需硬件">No hardware needed</li>
                     <li data-en="Boot + Ethernet verified on QEMU" data-zh="启动 + 以太网在 QEMU 上已验证">Boot + Ethernet verified on QEMU</li>
                     <li data-en="lan9118 user-mode networking" data-zh="lan9118 用户模式网络">lan9118 user-mode networking</li>
+                </ul>
+            </div>
+            <div class="platform-card reveal">
+                <h3>QEMU Zynq-A9</h3>
+                <div>
+                    <span class="platform-tag">ARM Cortex-A9</span>
+                    <span class="platform-tag">FreeRTOS</span>
+                    <span class="platform-tag">FreeRTOS+TCP</span>
+                    <span class="platform-tag">Cadence GEM</span>
+                </div>
+                <ul>
+                    <li data-en="Standalone FreeRTOS (non-ESP-IDF)" data-zh="独立 FreeRTOS（非 ESP-IDF）">Standalone FreeRTOS (non-ESP-IDF)</li>
+                    <li data-en="Full Meson firmware build" data-zh="完整 Meson 固件构建">Full Meson firmware build</li>
+                    <li data-en="DHCP + HTTP verified on QEMU" data-zh="DHCP + HTTP 在 QEMU 上已验证">DHCP + HTTP verified on QEMU</li>
+                    <li data-en="AI conversation via api-proxy" data-zh="通过 api-proxy 进行 AI 对话">AI conversation via api-proxy</li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## Summary

Update all project documentation to include the new Zynq-A9 QEMU platform with FreeRTOS+TCP networking.

## Changes

**README.md**:
- Add Zynq-A9 row to supported platforms table (FreeRTOS + FreeRTOS+TCP, Meson full firmware)
- Update ASCII architecture diagram with standalone FreeRTOS column

**CLAUDE.md**:
- Build: `make build-zynq-a9-qemu`
- Run: `make run-zynq-a9-qemu [GDB=1]`
- Testing: `make test-unit-zynq`, `make test-smoke-zynq`
- Key paths: `platform/zynq-a9/`, `vendor/bsp/xilinx/`, `vendor/lib/freertos-plus-tcp/`

**website/index.html**:
- New platform card: Zynq-A9 with FreeRTOS, FreeRTOS+TCP, Cadence GEM tags
- Features: standalone FreeRTOS, full Meson build, DHCP+HTTP verified, AI via api-proxy
- Architecture diagram updated

## Test plan

- [x] Website renders correctly with 4 platform cards
- [x] README table aligns properly
- [x] CLAUDE.md commands match actual Makefile targets