### PR TITLE
ci: disable automatic AI online integration tests

### DIFF
--- a/.github/workflows/ci-online-integration.yml
+++ b/.github/workflows/ci-online-integration.yml
@@ -1,24 +1,8 @@
 name: CI Online Integration
+# Disabled: AI API tests are inherently flaky (HTTP 503, rate limits, etc.)
+# and cause false-negative CI failures. Run manually when needed.
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'claw/**'
-      - 'osal/**'
-      - 'include/**'
-      - 'drivers/**'
-      - 'platform/esp32c3/**'
-      - 'platform/esp32s3/**'
-      - 'platform/common/**'
-      - 'scripts/**'
-      - 'tests/**'
-      - 'Makefile'
-      - 'meson.build'
-      - 'meson_options.txt'
-      - '.github/workflows/ci-online-integration.yml'
-  schedule:
-    - cron: '30 18 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Disable automatic triggers (push to main, daily schedule) for `ci-online-integration.yml`
- Keep `workflow_dispatch` so AI tests can still be run manually when needed
- Smoke tests (boot, shell, kv) remain fully automated and unaffected

## Reason

AI API tests (`test-online-esp32c3`, `test-online-esp32s3`) depend on external API availability and are inherently flaky:
- HTTP 503 from API providers (see [run #23234537247](https://github.com/zevorn/rt-claw/actions/runs/23234537247))
- Rate limiting, transient network failures
- These cause false-negative CI results that are not actionable

## Test plan

- [ ] Verify `ci-online-integration.yml` no longer triggers on push to main
- [ ] Verify manual trigger via Actions UI still works
- [ ] Confirm other CI workflows (build-matrix, qemu-correctness, nightly) are unaffected