### PR TITLE
platform: add interactive shell to Zynq-A9 QEMU

### DIFF
--- a/platform/zynq-a9/drivers/console.c
+++ b/platform/zynq-a9/drivers/console.c
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Console I/O driver for Zynq-A9 QEMU (Cadence UART).
+ * Implements claw_console_init/read/write for the shell.
+ */
+
+#include "drivers/serial/espressif/console.h"
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define UART_BASE  0xE0000000U
+
+/* Cadence UART register offsets */
+#define UART_CR    (*(volatile unsigned int *)(UART_BASE + 0x00))
+#define UART_SR    (*(volatile unsigned int *)(UART_BASE + 0x2C))
+#define UART_FIFO  (*(volatile unsigned int *)(UART_BASE + 0x30))
+
+#define UART_CR_TX_EN   (1U << 4)
+#define UART_CR_RX_EN   (1U << 2)
+#define UART_SR_TXFULL  (1U << 4)
+#define UART_SR_RXEMPTY (1U << 1)
+
+void claw_console_init(void)
+{
+    UART_CR = UART_CR_TX_EN | UART_CR_RX_EN;
+}
+
+int claw_console_read(void *buf, uint32_t len, uint32_t timeout_ms)
+{
+    uint8_t *p = (uint8_t *)buf;
+    TickType_t start = xTaskGetTickCount();
+    TickType_t ticks = (timeout_ms == UINT32_MAX)
+                       ? portMAX_DELAY
+                       : pdMS_TO_TICKS(timeout_ms);
+    uint32_t got = 0;
+
+    while (got < len) {
+        if (!(UART_SR & UART_SR_RXEMPTY)) {
+            p[got++] = (uint8_t)(UART_FIFO & 0xFF);
+        } else {
+            if (got > 0) {
+                break;
+            }
+            TickType_t elapsed = xTaskGetTickCount() - start;
+            if (ticks != portMAX_DELAY && elapsed >= ticks) {
+                break;
+            }
+            taskYIELD();
+        }
+    }
+
+    return (int)got;
+}
+
+int claw_console_write(const void *buf, size_t len)
+{
+    const uint8_t *p = (const uint8_t *)buf;
+
+    for (size_t i = 0; i < len; i++) {
+        while (UART_SR & UART_SR_TXFULL) {
+            /* wait */
+        }
+        UART_FIFO = (unsigned int)p[i];
+    }
+
+    return (int)len;
+}

--- a/platform/zynq-a9/main.c
+++ b/platform/zynq-a9/main.c
@@ -92,17 +92,22 @@ int main(void)
 }
 
 /* ------------------------------------------------------------------ */
-/* Main task — runs claw_init then idles                              */
+/* Main task — runs claw_init then starts shell                       */
 /* ------------------------------------------------------------------ */
+extern void zynq_shell_loop(void);
+
 static void claw_main_task(void *pvParameters)
 {
     (void)pvParameters;
 
     claw_init();
 
-    for (;;) {
-        vTaskDelay(pdMS_TO_TICKS(1000));
-    }
+    /* Wait for DHCP before starting shell */
+    printf("[init] waiting for network (10s)...\n");
+    vTaskDelay(pdMS_TO_TICKS(10000));
+
+    /* Enter interactive shell (does not return) */
+    zynq_shell_loop();
 }
 
 /* ------------------------------------------------------------------ */

--- a/platform/zynq-a9/meson.build
+++ b/platform/zynq-a9/meson.build
@@ -144,6 +144,8 @@ platform_src = files(
     'startup.S',
     'FreeRTOS_asm_vectors.S',
     'main.c',
+    'shell.c',
+    'drivers/console.c',
     'syscalls.c',
     'boards/qemu/board.c',
 )

--- a/platform/zynq-a9/shell.c
+++ b/platform/zynq-a9/shell.c
@@ -1,0 +1,491 @@
+/*
+ * Copyright (c) 2026, Chao Liu <chao.liu.zevorn@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * Interactive shell for Zynq-A9 QEMU (FreeRTOS).
+ *
+ * Chat-first REPL with full line editing:
+ *   - Insert mode with left/right arrows, home/end, delete
+ *   - UTF-8 aware backspace and cursor movement (CJK fullwidth)
+ *   - Tab completion for /commands
+ *   - Thinking animation during AI calls
+ */
+
+#include "osal/claw_os.h"
+#include "claw/services/ai/ai_engine.h"
+#include "claw/shell/shell_commands.h"
+#include "claw_board.h"
+#include "drivers/serial/espressif/console.h"
+
+#include <stdio.h>
+#include <string.h>
+
+
+#define TAG         "shell"
+#define REPLY_SIZE  4096
+#define INPUT_SIZE  256
+#define MAX_ARGS    8
+
+static char *s_reply;
+
+/* ---- Line editing helpers ---- */
+
+static void redraw_from(const char *buf, int len, int cursor)
+{
+    int tail = len - cursor;
+
+    if (tail > 0) {
+        claw_console_write(buf + cursor, tail);
+    }
+    /* Clear one trailing char (covers deleted character) */
+    claw_console_write(" ", 1);
+    /* Move cursor back to correct position */
+    for (int i = 0; i < tail + 1; i++) {
+        claw_console_write("\b", 1);
+    }
+}
+
+/* Forward declaration */
+static void find_completions(const char *prefix, int prefix_len,
+                             const char **match, int *match_count);
+
+/*
+ * Read one line with insert-mode editing.
+ * Supports: left/right arrows, backspace, delete, home, end,
+ * tab completion for /commands, UTF-8 passthrough.
+ */
+static int shell_read_line(char *buf, int size)
+{
+    int len = 0;     /* total chars in buffer */
+    int cursor = 0;  /* cursor position */
+    uint8_t ch;
+
+    while (len < size - 1) {
+        int n = claw_console_read(&ch, 1, UINT32_MAX);
+        if (n <= 0) {
+            continue;
+        }
+
+        /* Enter */
+        if (ch == '\r' || ch == '\n') {
+            claw_console_write("\r\n", 2);
+            uint8_t trail;
+            claw_console_read(&trail, 1, 20);
+            break;
+        }
+
+        /* Tab completion */
+        if (ch == '\t') {
+            if (len > 0 && buf[0] == '/') {
+                buf[len] = '\0';
+                const char *match = NULL;
+                int match_count = 0;
+                find_completions(buf, len, &match, &match_count);
+                if (match_count == 1 && match) {
+                    int mlen = (int)strlen(match);
+                    /* Clear current line */
+                    while (cursor > 0) {
+                        claw_console_write("\b \b", 3);
+                        cursor--;
+                    }
+                    for (int i = 0; i < len; i++) {
+                        claw_console_write(" ", 1);
+                    }
+                    for (int i = 0; i < len; i++) {
+                        claw_console_write("\b", 1);
+                    }
+                    /* Fill in match */
+                    memcpy(buf, match, mlen);
+                    buf[mlen] = ' ';
+                    len = mlen + 1;
+                    cursor = len;
+                    claw_console_write(buf, len);
+                }
+            }
+            continue;
+        }
+
+        /* Backspace — UTF-8 aware */
+        if (ch == '\b' || ch == 127) {
+            if (cursor > 0) {
+                /*
+                 * Walk back over a complete UTF-8 sequence.
+                 * Continuation bytes are 10xxxxxx (0x80..0xBF).
+                 */
+                int del = 1;
+                while (del < cursor &&
+                       (buf[cursor - del] & 0xC0) == 0x80) {
+                    del++;
+                }
+
+                /* Determine display width: CJK fullwidth = 2 cols */
+                int cols = 1;
+                uint8_t lead = (uint8_t)buf[cursor - del];
+                if (del == 3 && (lead & 0xF0) == 0xE0) {
+                    /* 3-byte UTF-8: U+0800..U+FFFF (CJK range) */
+                    cols = 2;
+                } else if (del == 4 && (lead & 0xF8) == 0xF0) {
+                    /* 4-byte UTF-8: supplementary (emoji etc.) */
+                    cols = 2;
+                }
+
+                memmove(buf + cursor - del, buf + cursor,
+                        len - cursor);
+                cursor -= del;
+                len -= del;
+
+                for (int i = 0; i < cols; i++) {
+                    claw_console_write("\b", 1);
+                }
+                redraw_from(buf, len, cursor);
+            }
+            continue;
+        }
+
+        /* Escape sequences (arrows, home, end, delete) */
+        if (ch == 0x1B) {
+            uint8_t seq[2];
+            if (claw_console_read(&seq[0], 1, 50) <= 0) {
+                continue;
+            }
+            if (seq[0] != '[') {
+                continue;
+            }
+            if (claw_console_read(&seq[1], 1, 50) <= 0) {
+                continue;
+            }
+
+            /* Numeric sequences: ESC [ <digit> ~ */
+            if (seq[1] >= '0' && seq[1] <= '9') {
+                uint8_t tilde;
+                claw_console_read(&tilde, 1, 50);
+                if (seq[1] == '3' && tilde == '~') {
+                    /* Delete key — UTF-8 aware */
+                    if (cursor < len) {
+                        int del = 1;
+                        uint8_t lead = (uint8_t)buf[cursor];
+                        if ((lead & 0x80) != 0) {
+                            if ((lead & 0xE0) == 0xC0) {
+                                del = 2;
+                            } else if ((lead & 0xF0) == 0xE0) {
+                                del = 3;
+                            } else if ((lead & 0xF8) == 0xF0) {
+                                del = 4;
+                            }
+                            if (cursor + del > len) {
+                                del = len - cursor;
+                            }
+                        }
+                        memmove(buf + cursor, buf + cursor + del,
+                                len - cursor - del);
+                        len -= del;
+                        redraw_from(buf, len, cursor);
+                    }
+                }
+                /* Other numeric sequences silently consumed */
+                continue;
+            }
+
+            switch (seq[1]) {
+            case 'D': /* Left arrow — UTF-8 aware */
+                if (cursor > 0) {
+                    int skip = 1;
+                    while (skip < cursor &&
+                           (buf[cursor - skip] & 0xC0) == 0x80) {
+                        skip++;
+                    }
+                    int cols = 1;
+                    uint8_t ld = (uint8_t)buf[cursor - skip];
+                    if (skip == 3 && (ld & 0xF0) == 0xE0) {
+                        cols = 2;
+                    } else if (skip == 4 && (ld & 0xF8) == 0xF0) {
+                        cols = 2;
+                    }
+                    cursor -= skip;
+                    char esc[8];
+                    int elen = snprintf(esc, sizeof(esc),
+                                        "\033[%dD", cols);
+                    claw_console_write(esc, elen);
+                }
+                break;
+            case 'C': /* Right arrow — UTF-8 aware */
+                if (cursor < len) {
+                    int skip = 1;
+                    uint8_t ld = (uint8_t)buf[cursor];
+                    if ((ld & 0xE0) == 0xC0) {
+                        skip = 2;
+                    } else if ((ld & 0xF0) == 0xE0) {
+                        skip = 3;
+                    } else if ((ld & 0xF8) == 0xF0) {
+                        skip = 4;
+                    }
+                    if (cursor + skip > len) {
+                        skip = len - cursor;
+                    }
+                    int cols = 1;
+                    if (skip == 3 && (ld & 0xF0) == 0xE0) {
+                        cols = 2;
+                    } else if (skip == 4 && (ld & 0xF8) == 0xF0) {
+                        cols = 2;
+                    }
+                    cursor += skip;
+                    char esc[8];
+                    int elen = snprintf(esc, sizeof(esc),
+                                        "\033[%dC", cols);
+                    claw_console_write(esc, elen);
+                }
+                break;
+            case 'H': /* Home */
+                while (cursor > 0) {
+                    cursor--;
+                    claw_console_write("\033[D", 3);
+                }
+                break;
+            case 'F': /* End */
+                while (cursor < len) {
+                    cursor++;
+                    claw_console_write("\033[C", 3);
+                }
+                break;
+            default:
+                break;
+            }
+            continue;
+        }
+
+        /*
+         * Normal character — insert at cursor.
+         * For UTF-8 multi-byte sequences, read all continuation
+         * bytes before inserting so the character appears atomically.
+         */
+        int seq_len = 1;
+        uint8_t mb[4];
+        mb[0] = ch;
+
+        if ((ch & 0xE0) == 0xC0) {
+            seq_len = 2;
+        } else if ((ch & 0xF0) == 0xE0) {
+            seq_len = 3;
+        } else if ((ch & 0xF8) == 0xF0) {
+            seq_len = 4;
+        }
+
+        for (int i = 1; i < seq_len; i++) {
+            if (claw_console_read(&mb[i], 1, 100) <= 0) {
+                seq_len = i;
+                break;
+            }
+        }
+
+        if (len + seq_len >= size) {
+            continue;
+        }
+
+        if (cursor < len) {
+            memmove(buf + cursor + seq_len, buf + cursor,
+                    len - cursor);
+        }
+        memcpy(buf + cursor, mb, seq_len);
+        len += seq_len;
+        cursor += seq_len;
+
+        /* Echo the complete character */
+        claw_console_write(mb, seq_len);
+        if (cursor < len) {
+            redraw_from(buf, len, cursor);
+        }
+    }
+
+    buf[len] = '\0';
+    return len;
+}
+
+/* ---- Command table ---- */
+
+static void cmd_help(int argc, char **argv);
+
+static const shell_cmd_t s_builtin_commands[] = {
+    SHELL_CMD("/help", cmd_help, "Show this help"),
+};
+
+static void cmd_help(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    int board_cmd_count = 0;
+    const shell_cmd_t *board_cmds = board_platform_commands(&board_cmd_count);
+
+    shell_print_help(s_builtin_commands,
+                     SHELL_CMD_COUNT(s_builtin_commands));
+    if (board_cmds && board_cmd_count > 0) {
+        shell_print_help(board_cmds, board_cmd_count);
+    }
+    shell_print_help(shell_common_commands,
+                     shell_common_command_count());
+    printf("\n  Anything else is sent directly to AI.\n");
+}
+
+/* ---- Tab completion for /commands ---- */
+
+static void find_completions(const char *prefix, int prefix_len,
+                             const char **match, int *match_count)
+{
+    *match = NULL;
+    *match_count = 0;
+
+    const struct {
+        const shell_cmd_t *table;
+        int count;
+    } tables[] = {
+        { s_builtin_commands, SHELL_CMD_COUNT(s_builtin_commands) },
+        { shell_common_commands, shell_common_command_count() },
+    };
+    int board_count = 0;
+    const shell_cmd_t *board = board_platform_commands(&board_count);
+
+    for (int t = 0; t < 2; t++) {
+        for (int i = 0; i < tables[t].count; i++) {
+            if (strncmp(tables[t].table[i].name, prefix,
+                        prefix_len) == 0) {
+                *match = tables[t].table[i].name;
+                (*match_count)++;
+            }
+        }
+    }
+    if (board) {
+        for (int i = 0; i < board_count; i++) {
+            if (strncmp(board[i].name, prefix, prefix_len) == 0) {
+                *match = board[i].name;
+                (*match_count)++;
+            }
+        }
+    }
+}
+
+/* ---- Command dispatch ---- */
+
+static void dispatch_command(char *line)
+{
+    char *argv[MAX_ARGS];
+    int argc = shell_tokenize(line, argv, MAX_ARGS);
+
+    if (argc == 0) {
+        return;
+    }
+    if (shell_dispatch(s_builtin_commands,
+                       SHELL_CMD_COUNT(s_builtin_commands),
+                       argc, argv)) {
+        return;
+    }
+
+    int board_cmd_count = 0;
+    const shell_cmd_t *board_cmds = board_platform_commands(&board_cmd_count);
+    if (board_cmds && shell_dispatch(board_cmds, board_cmd_count,
+                                     argc, argv)) {
+        return;
+    }
+
+    if (shell_dispatch(shell_common_commands,
+                       shell_common_command_count(),
+                       argc, argv)) {
+        return;
+    }
+    printf("Unknown command: %s (type /help)\n", argv[0]);
+}
+
+/* ---- Thinking animation ---- */
+
+static volatile int s_anim_active;
+static volatile int s_anim_phase;
+
+static void anim_thread_fn(void *arg)
+{
+    (void)arg;
+    int dots = 0;
+    const char *dot_str[] = { ".", "..", "..." };
+
+    while (s_anim_active) {
+        if (s_anim_phase == 0) {
+            printf("\r  " CLR_MAGENTA "thinking %s"
+                   CLR_RESET "   ", dot_str[dots]);
+            fflush(stdout);
+            dots = (dots + 1) % 3;
+        }
+        claw_thread_delay_ms(500);
+    }
+}
+
+static void chat_status_cb(int status, const char *detail)
+{
+    if (status == AI_STATUS_THINKING) {
+        s_anim_phase = 0;
+    } else if (status == AI_STATUS_TOOL_CALL) {
+        s_anim_phase = 1;
+        printf("\r  " CLR_YELLOW "► %s" CLR_RESET
+               "                    \n",
+               detail ? detail : "?");
+        fflush(stdout);
+    } else if (status == AI_STATUS_DONE) {
+        s_anim_active = 0;
+    }
+}
+
+static void do_chat(const char *msg)
+{
+    s_anim_active = 1;
+    s_anim_phase = 0;
+    ai_set_status_cb(chat_status_cb);
+
+    claw_thread_create("anim", anim_thread_fn, NULL, 2048, 20);
+
+    int ret = ai_chat(msg, s_reply, REPLY_SIZE);
+
+    s_anim_active = 0;
+    ai_set_status_cb(NULL);
+    claw_thread_delay_ms(100);
+    printf("\r                              \r");
+
+    if (ret == CLAW_OK) {
+        printf(CLR_GREEN "<rt-claw> " CLR_RESET "%s\n", s_reply);
+    } else {
+        printf(CLR_RED "<error> " CLR_RESET "%s\n", s_reply);
+    }
+}
+
+/* ---- Public API ---- */
+
+void zynq_shell_loop(void)
+{
+    char input[INPUT_SIZE];
+
+    claw_console_init();
+
+    s_reply = claw_malloc(REPLY_SIZE);
+    if (!s_reply) {
+        CLAW_LOGE(TAG, "no memory for reply buffer");
+        return;
+    }
+
+    printf("\n");
+    printf(CLR_CYAN "  rt-claw chat" CLR_RESET
+           "  (type /help for commands)\n");
+    printf("  Direct input sends to AI, /command for system.\n");
+    printf("\n");
+
+    while (1) {
+        printf("\n" CLR_CYAN "<You> " CLR_RESET);
+        fflush(stdout);
+        int len = shell_read_line(input, sizeof(input));
+
+        if (len == 0) {
+            continue;
+        }
+
+        if (input[0] == '/') {
+            dispatch_command(input);
+        } else {
+            do_chat(input);
+        }
+    }
+}
+

--- a/platform/zynq-a9/syscalls.c
+++ b/platform/zynq-a9/syscalls.c
@@ -162,6 +162,13 @@ const char *pcApplicationHostnameHook(void)
     return "rt-claw";
 }
 
+/* Scheduler tool stub — tool_sched.c is ESP-IDF only (uses NVS) */
+int sched_tool_remove_by_name(const char *name)
+{
+    (void)name;
+    return -1;
+}
+
 /* ARM exception handler stubs */
 void FIQInterrupt(void) { while (1); }
 


### PR DESCRIPTION
## Summary

Add chat-first interactive shell to the Zynq-A9 QEMU platform, bringing feature parity with ESP32 platforms.

## Components

**Console driver** (`platform/zynq-a9/drivers/console.c`):
- Cadence UART RX/TX at 0xE0000000
- `claw_console_read()` with timeout and taskYIELD polling
- `claw_console_write()` via UART FIFO

**Shell** (`platform/zynq-a9/shell.c`):
- Full chat-first REPL ported from `esp_shell.c`
- Insert-mode line editing (arrows, backspace, delete, home/end)
- UTF-8 aware cursor movement (CJK fullwidth)
- Tab completion for /commands
- Thinking animation during AI calls
- Direct input → AI, /command → system dispatch

## Boot sequence

```
rt-claw: Zynq-A9 QEMU (FreeRTOS) - Real-Time Claw
[I/init] init: gateway / sched / swarm / net / tools / ai_engine / ai_skill
[init] waiting for network (10s)...

  rt-claw chat  (type /help for commands)
  Direct input sends to AI, /command for system.

<You> _
```

## Test plan

- [x] `make build-zynq-a9-qemu` compiles (shell + console driver)
- [x] `make run-zynq-a9-qemu` shows shell prompt `<You>`
- [x] QEMU `-nographic` stdin → UART RX works
- [ ] `/help` command lists available commands
- [ ] AI chat via api-proxy