### PR TITLE
platform: disable FreeRTOS+TCP verbose logging on Zynq-A9

### DIFF
--- a/platform/zynq-a9/FreeRTOSIPConfig.h
+++ b/platform/zynq-a9/FreeRTOSIPConfig.h
@@ -57,11 +57,9 @@
 /* Callbacks */
 #define ipconfigUSE_NETWORK_EVENT_HOOK          1
 
-/* Logging — map to printf */
-#define ipconfigHAS_PRINTF                      1
-#define FreeRTOS_printf(X)                      printf X
-#define ipconfigHAS_DEBUG_PRINTF                1
-#define FreeRTOS_debug_printf(X)                printf X
+/* Logging — disabled to keep shell output clean */
+#define ipconfigHAS_PRINTF                      0
+#define ipconfigHAS_DEBUG_PRINTF                0
 
 /* Multi-interface support (required by latest FreeRTOS+TCP) */
 #define ipconfigUSE_DHCP_HOOK                   0

--- a/platform/zynq-a9/drivers/NetworkInterface.c
+++ b/platform/zynq-a9/drivers/NetworkInterface.c
@@ -395,8 +395,6 @@ static BaseType_t xZynqNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
                                                NetworkBufferDescriptor_t * const pxBuffer,
                                                BaseType_t bReleaseAfterSend )
 {
-    FreeRTOS_printf( ( "GEM TX: len=%lu buf=%p\n",
-                       pxBuffer->xDataLength, pxBuffer->pucEthernetBuffer ) );
     BaseType_t xEMACIndex = ( BaseType_t ) pxInterface->pvArgument;
 
     configASSERT( xEMACIndex >= 0 );

--- a/platform/zynq-a9/main.c
+++ b/platform/zynq-a9/main.c
@@ -64,7 +64,7 @@ static void init_network(void)
     xEndPoint.bits.bWantDHCP = pdTRUE;
 
     FreeRTOS_IPInit_Multi();
-    printf("[net] FreeRTOS+TCP initialized, waiting for DHCP...\n");
+    /* FreeRTOS+TCP init done; [net] network up prints on DHCP success */
 }
 
 int main(void)
@@ -103,7 +103,7 @@ static void claw_main_task(void *pvParameters)
     claw_init();
 
     /* Wait for DHCP before starting shell */
-    printf("[init] waiting for network (10s)...\n");
+    /* Wait for DHCP before starting shell */
     vTaskDelay(pdMS_TO_TICKS(10000));
 
     /* Enter interactive shell (does not return) */


### PR DESCRIPTION
## Summary

Disable FreeRTOS+TCP verbose debug logging that floods the interactive shell output on Zynq-A9 QEMU.

## Problem

Shell output was polluted with TCP/IP internals:
```
<You>  thinking ..   MSS change 1400 -> 1460
TCP: active 24024 => 163.25.18.104 port 443 set ESTAB
FreeRTOS_FindEndPointOnNetMask: No match for 681219a3ip
ARP 681219a3ip hit using a000202ip
GEM TX: len=276 buf=0x19bc52
...
```

## Fix

- `ipconfigHAS_PRINTF=0`, `ipconfigHAS_DEBUG_PRINTF=0` in FreeRTOSIPConfig.h
- Remove GEM TX debug printf from NetworkInterface.c
- Remove verbose `[net]` and `[init]` prints from main.c
- Keep `[net] network up: x.x.x.x` on DHCP success

## After

```
rt-claw: Zynq-A9 QEMU (FreeRTOS) - Real-Time Claw
[I/init] init: gateway / sched / swarm / net / tools / ai_engine
[net] network up: 10.0.2.15

  rt-claw chat  (type /help for commands)

<You> _
```

## Test plan

- [x] `make build-zynq-a9-qemu` compiles
- [x] `make run-zynq-a9-qemu` — clean shell output, no TCP/ARP spam