### PR TITLE
net: add /ip shell command to display network address

### DIFF
--- a/claw/services/net/net_service.c
+++ b/claw/services/net/net_service.c
@@ -165,24 +165,66 @@ int net_service_init(void)
     return CLAW_OK;
 }
 
+void net_print_ipinfo(void)
+{
+    esp_netif_ip_info_t info;
+
+    if (s_eth_netif &&
+        esp_netif_get_ip_info(s_eth_netif, &info) == ESP_OK &&
+        info.ip.addr != 0) {
+        printf("  ip:      " IPSTR "\n", IP2STR(&info.ip));
+        printf("  netmask: " IPSTR "\n", IP2STR(&info.netmask));
+        printf("  gateway: " IPSTR "\n", IP2STR(&info.gw));
+    } else {
+        printf("  (no IP address)\n");
+    }
+}
+
 #elif defined(CLAW_PLATFORM_ESP_IDF)
 /*
  * ESP-IDF without Ethernet (WiFi-only, real hardware).
  * Network is initialized by platform main.c (wifi_manager).
  */
+
+#include "esp_netif.h"
+
 int net_service_init(void)
 {
     CLAW_LOGI(TAG, "network service ready (WiFi managed by platform)");
     return CLAW_OK;
 }
 
+void net_print_ipinfo(void)
+{
+    esp_netif_t *netif = NULL;
+    int found = 0;
+
+    while ((netif = esp_netif_next_unsafe(netif)) != NULL) {
+        esp_netif_ip_info_t info;
+        if (esp_netif_get_ip_info(netif, &info) == ESP_OK &&
+            info.ip.addr != 0) {
+            const char *desc = esp_netif_get_desc(netif);
+            printf("  %s:\n", desc ? desc : "netif");
+            printf("    ip:      " IPSTR "\n", IP2STR(&info.ip));
+            printf("    netmask: " IPSTR "\n", IP2STR(&info.netmask));
+            printf("    gateway: " IPSTR "\n", IP2STR(&info.gw));
+            found = 1;
+        }
+    }
+    if (!found) {
+        printf("  (no IP address)\n");
+    }
+}
+
 #elif defined(CLAW_PLATFORM_RTTHREAD)
 
 #include "claw/platform_net.h"
 
+#include <stdio.h>
 #include <rtthread.h>
 #include <netif/ethernetif.h>
 #include "lwip/ip4_addr.h"
+#include "lwip/netif.h"
 
 const char *claw_platform_net_device_name(void) __attribute__((weak));
 void claw_platform_net_prepare(void) __attribute__((weak));
@@ -276,12 +318,32 @@ int net_service_init(void)
     return CLAW_OK;
 }
 
+void net_print_ipinfo(void)
+{
+    struct netif *nif = netif_default;
+
+    if (nif && nif->ip_addr.addr != 0) {
+        printf("  ip:      %s\n", ip4addr_ntoa(&nif->ip_addr));
+        printf("  netmask: %s\n", ip4addr_ntoa(&nif->netmask));
+        printf("  gateway: %s\n", ip4addr_ntoa(&nif->gw));
+    } else {
+        printf("  (no IP address)\n");
+    }
+}
+
 #else /* unknown platform */
+
+#include <stdio.h>
 
 int net_service_init(void)
 {
     CLAW_LOGI(TAG, "service initialized (network backend pending)");
     return CLAW_OK;
+}
+
+void net_print_ipinfo(void)
+{
+    printf("  (not available on this platform)\n");
 }
 
 #endif

--- a/claw/shell/shell_commands.c
+++ b/claw/shell/shell_commands.c
@@ -15,6 +15,7 @@
 #include "claw/services/ai/ai_memory.h"
 #include "claw/tools/claw_tools.h"
 #include "claw/services/im/feishu.h"
+#include "claw/services/net/net_service.h"
 
 #ifdef CONFIG_RTCLAW_SKILL_ENABLE
 #include "claw/services/ai/ai_skill.h"
@@ -372,6 +373,14 @@ static void cmd_ota(int argc, char **argv)
 }
 #endif
 
+static void cmd_ip(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    printf("Network:\n");
+    net_print_ipinfo();
+}
+
 /* ---- Common command table ---- */
 
 const shell_cmd_t shell_common_commands[] = {
@@ -382,6 +391,7 @@ const shell_cmd_t shell_common_commands[] = {
     SHELL_CMD("/ai_status",     cmd_ai_status,     "Show AI config"),
     SHELL_CMD("/feishu_set",    cmd_feishu_set,    "Set Feishu creds (NVS)"),
     SHELL_CMD("/feishu_status", cmd_feishu_status, "Show Feishu config"),
+    SHELL_CMD("/ip",            cmd_ip,            "Show IP address"),
     SHELL_CMD("/remember",      cmd_remember,      "Save to long-term memory"),
     SHELL_CMD("/forget",        cmd_forget,        "Delete a long-term memory"),
     SHELL_CMD("/memories",      cmd_memories,      "List long-term memories"),

--- a/include/claw/services/net/net_service.h
+++ b/include/claw/services/net/net_service.h
@@ -10,4 +10,10 @@
 
 int net_service_init(void);
 
+/*
+ * Print IP address info to stdout.
+ * Output format varies by platform but always includes IP, netmask, gateway.
+ */
+void net_print_ipinfo(void);
+
 #endif /* CLAW_SERVICES_NET_SERVICE_H */


### PR DESCRIPTION
## Summary

- Add `net_print_ipinfo()` with per-platform implementations (ESP-IDF Ethernet, ESP-IDF WiFi, RT-Thread lwIP, fallback)
- Register `/ip` in common shell command table

## Usage

```
/ip
Network:
  ip:      10.0.2.15
  netmask: 255.255.255.0
  gateway: 10.0.2.2
```

## Test plan

- [ ] `make run-vexpress-a9-qemu` → `/ip` prints lwIP netif_default address
- [ ] `make run-esp32c3-qemu` → `/ip` prints OpenCores Ethernet address
- [ ] ESP32 WiFi hardware → `/ip` lists WiFi STA interface