### PR TITLE
platform: add Python script runtimes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,7 @@
 [submodule "vendor/lib/freertos-plus-tcp"]
 	path = vendor/lib/freertos-plus-tcp
 	url = https://github.com/FreeRTOS/FreeRTOS-Plus-TCP.git
+[submodule "third_party/rtthread-micropython"]
+	path = third_party/rtthread-micropython
+	url = https://github.com/RT-Thread-packages/micropython.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,4 @@
 	path = third_party/rtthread-micropython
 	url = https://github.com/RT-Thread-packages/micropython.git
 	branch = master
+	ignore = untracked

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,10 @@ A9_PLATFORM       := platform/vexpress-a9
 .PHONY: vexpress-a9-qemu
 vexpress-a9-qemu:
 	@if [ ! -f $(MESON_BUILDDIR_A9)/build.ninja ]; then \
-		meson setup $(MESON_BUILDDIR_A9) --cross-file $(CROSS_FILE_A9); \
+		meson setup $(MESON_BUILDDIR_A9) --cross-file $(CROSS_FILE_A9) \
+			-Dtool_script=true; \
+	else \
+		meson configure $(MESON_BUILDDIR_A9) -Dtool_script=true; \
 	fi
 	meson compile -C $(MESON_BUILDDIR_A9)
 	cd $(A9_PLATFORM) && scons -j$$(nproc)
@@ -374,7 +377,10 @@ MESON_BUILDDIR_LINUX := $(BUILD_DIR)/linux
 .PHONY: build-linux
 build-linux:
 	@if [ ! -f $(MESON_BUILDDIR_LINUX)/build.ninja ]; then \
-		meson setup $(MESON_BUILDDIR_LINUX) -Dosal=linux; \
+		meson setup $(MESON_BUILDDIR_LINUX) -Dosal=linux \
+			-Dtool_script=true; \
+	else \
+		meson configure $(MESON_BUILDDIR_LINUX) -Dtool_script=true; \
 	fi
 	meson compile -C $(MESON_BUILDDIR_LINUX)
 	@echo "Output: $(MESON_BUILDDIR_LINUX)/platform/linux/rtclaw"
@@ -526,6 +532,7 @@ test-smoke-esp32s3:
 .PHONY: test-smoke-vexpress
 test-smoke-vexpress: vexpress-a9-qemu
 	$(call _functest,vexpress-a9-qemu,test_boot.py)
+	$(call _functest,vexpress-a9-qemu,test_vexpress_micropython.py)
 
 .PHONY: test-online-esp32c3
 test-online-esp32c3: run-esp32c3-qemu-flash

--- a/claw/meson.build
+++ b/claw/meson.build
@@ -62,6 +62,10 @@ if get_option('tool_net')
     feature_defs += '-DCONFIG_RTCLAW_TOOL_NET'
     src_files += files('services/tools/net.c')
 endif
+if get_option('tool_script')
+    feature_defs += '-DCONFIG_RTCLAW_TOOL_SCRIPT'
+    src_files += files('services/tools/script.c')
+endif
 if get_option('tool_mouse')
     feature_defs += '-DCONFIG_RTCLAW_TOOL_MOUSE'
     src_files += files('services/tools/mouse.c')

--- a/claw/services/tools/script.c
+++ b/claw/services/tools/script.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026, Chao Liu <chao.liu.zevorn@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * Script execution tool.
+ */
+
+#include "claw/services/tools/tools.h"
+#include "platform/scripting.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define SCRIPT_OUTPUT_MAX 1024
+#define SCRIPT_LANGUAGE_MICROPYTHON "micropython"
+
+__attribute__((weak))
+int claw_platform_script_supported(const char *language)
+{
+    (void)language;
+    return 0;
+}
+
+__attribute__((weak))
+int claw_platform_run_script(const char *language, const char *code,
+                             char *output, size_t output_size)
+{
+    (void)language;
+    (void)code;
+    if (output && output_size > 0) {
+        output[0] = '\0';
+    }
+    return -1;
+}
+
+static const char *script_language_from_params(const cJSON *params)
+{
+    const cJSON *language = cJSON_GetObjectItem(params, "language");
+
+    if (language && cJSON_IsString(language)) {
+        return language->valuestring;
+    }
+
+    return SCRIPT_LANGUAGE_MICROPYTHON;
+}
+
+static claw_err_t tool_run_script_validate(struct claw_tool *tool,
+                                           const cJSON *params)
+{
+    const cJSON *code;
+    const cJSON *language;
+
+    (void)tool;
+    if (!params) {
+        return CLAW_ERR_INVALID;
+    }
+
+    code = cJSON_GetObjectItem(params, "code");
+    language = cJSON_GetObjectItem(params, "language");
+
+    if (!code || !cJSON_IsString(code)) {
+        return CLAW_ERR_INVALID;
+    }
+
+    if (language && !cJSON_IsString(language)) {
+        return CLAW_ERR_INVALID;
+    }
+
+    return CLAW_OK;
+}
+
+static claw_err_t tool_run_script_execute(struct claw_tool *tool,
+                                          const cJSON *params,
+                                          cJSON *result)
+{
+    const cJSON *code = cJSON_GetObjectItem(params, "code");
+    const char *language = script_language_from_params(params);
+    char *output;
+
+    (void)tool;
+    output = claw_malloc(SCRIPT_OUTPUT_MAX);
+    if (!output) {
+        cJSON_AddStringToObject(result, "error", "out of memory");
+        return CLAW_OK;
+    }
+    output[0] = '\0';
+
+    if (!claw_platform_script_supported(language)) {
+        char msg[64];
+
+        snprintf(msg, sizeof(msg), "runtime '%s' not supported", language);
+        cJSON_AddStringToObject(result, "error", msg);
+        claw_free(output);
+        return CLAW_OK;
+    }
+
+    if (claw_platform_run_script(language, code->valuestring,
+                                 output, SCRIPT_OUTPUT_MAX) != 0) {
+        cJSON_AddStringToObject(result, "error",
+                                output[0] ? output
+                                          : "script execution failed");
+        claw_free(output);
+        return CLAW_OK;
+    }
+
+    cJSON_AddStringToObject(result, "status", "ok");
+    cJSON_AddStringToObject(result, "language", language);
+    cJSON_AddStringToObject(result, "output", output);
+    if (strlen(output) >= SCRIPT_OUTPUT_MAX - 1) {
+        cJSON_AddBoolToObject(result, "truncated", 1);
+    }
+
+    claw_free(output);
+    return CLAW_OK;
+}
+
+static const char schema_run_script[] =
+    "{\"type\":\"object\","
+    "\"properties\":{"
+    "\"language\":{\"type\":\"string\","
+    "\"description\":\"Scripting runtime. Defaults to micropython.\"},"
+    "\"code\":{\"type\":\"string\","
+    "\"description\":\"Script source code to execute on-device.\"}},"
+    "\"required\":[\"code\"]}";
+
+static const struct claw_tool_ops run_script_ops = {
+    .execute = tool_run_script_execute,
+    .validate_params = tool_run_script_validate,
+};
+
+static struct claw_tool run_script_tool = {
+    .name = "run_script",
+    .description =
+        "Execute a short on-device script and return stdout or "
+        "exception output. RT-Thread uses MicroPython, Linux uses Python.",
+    .input_schema_json = schema_run_script,
+    .ops = &run_script_ops,
+    .flags = CLAW_TOOL_LOCAL_ONLY,
+};
+
+CLAW_TOOL_REGISTER(run_script, &run_script_tool);

--- a/include/platform/scripting.h
+++ b/include/platform/scripting.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, Chao Liu <chao.liu.zevorn@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * Platform hooks for embedded script execution.
+ */
+
+#ifndef PLATFORM_SCRIPTING_H
+#define PLATFORM_SCRIPTING_H
+
+#include <stddef.h>
+
+/*
+ * Return 1 when the given runtime is available on this platform.
+ * Current users pass "micropython".
+ */
+int claw_platform_script_supported(const char *language);
+
+/*
+ * Execute script source with the selected runtime.
+ * Returns 0 on success, -1 on failure.
+ * output receives stdout / exception text when available.
+ */
+int claw_platform_run_script(const char *language, const char *code,
+                             char *output, size_t output_size);
+
+#endif /* PLATFORM_SCRIPTING_H */

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,6 +24,8 @@ option('tool_sched', type: 'boolean', value: true,
     description: 'Enable scheduler tool')
 option('tool_net', type: 'boolean', value: true,
     description: 'Enable network (HTTP) tool')
+option('tool_script', type: 'boolean', value: false,
+    description: 'Enable embedded script execution tool')
 option('tool_mouse', type: 'boolean', value: false,
     description: 'Enable USB HID mouse tools (ESP32-S3 only)')
 option('heartbeat', type: 'boolean', value: false,

--- a/platform/linux/board.c
+++ b/platform/linux/board.c
@@ -7,6 +7,56 @@
 
 #include "platform/board.h"
 
+#ifdef CONFIG_RTCLAW_TOOL_SCRIPT
+#include "platform/scripting.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define PYTHON_CODE_SIZE   256
+#define PYTHON_OUTPUT_SIZE 1024
+
+static void cmd_python(int argc, char **argv)
+{
+    char code[PYTHON_CODE_SIZE];
+    char output[PYTHON_OUTPUT_SIZE];
+    int off = 0;
+
+    if (argc < 2) {
+        claw_printf("Usage: /python <code>\n");
+        return;
+    }
+
+    code[0] = '\0';
+    for (int i = 1; i < argc && off < (int)sizeof(code) - 1; i++) {
+        off += snprintf(code + off, sizeof(code) - off,
+                        "%s%s", i > 1 ? " " : "", argv[i]);
+        if (off >= (int)sizeof(code)) {
+            code[sizeof(code) - 1] = '\0';
+            break;
+        }
+    }
+
+    if (claw_platform_run_script("python", code,
+                                 output, sizeof(output)) != 0) {
+        claw_printf("%s\n",
+                    output[0] ? output : "Python execution failed");
+        return;
+    }
+
+    if (output[0] != '\0') {
+        claw_printf("%s", output);
+        if (output[strlen(output) - 1] != '\n') {
+            claw_printf("\n");
+        }
+    }
+}
+
+static const shell_cmd_t s_linux_commands[] = {
+    SHELL_CMD("/python", cmd_python, "Execute a short Python snippet"),
+};
+#endif
+
 void board_early_init(void)
 {
     /* No hardware init needed on Linux */
@@ -14,6 +64,11 @@ void board_early_init(void)
 
 const shell_cmd_t *board_platform_commands(int *count)
 {
+#ifdef CONFIG_RTCLAW_TOOL_SCRIPT
+    *count = SHELL_CMD_COUNT(s_linux_commands);
+    return s_linux_commands;
+#else
     *count = 0;
     return NULL;
+#endif
 }

--- a/platform/linux/meson.build
+++ b/platform/linux/meson.build
@@ -8,12 +8,21 @@ platform_src = files(
     'ota_stub.c',
 )
 
+if get_option('tool_script')
+    platform_src += files('scripting.c')
+endif
+
 thread_dep = dependency('threads')
+platform_c_args = platform_defs
+
+if get_option('tool_script')
+    platform_c_args += '-DCONFIG_RTCLAW_TOOL_SCRIPT'
+endif
 
 rtclaw_exe = executable('rtclaw',
     platform_src,
     include_directories: [claw_inc, claw_root_inc],
-    c_args: platform_defs,
+    c_args: platform_c_args,
     dependencies: [rtclaw_dep, osal_dep, cjson_dep, thread_dep],
     install: false,
 )
@@ -21,11 +30,16 @@ rtclaw_exe = executable('rtclaw',
 # Unit test executable — links ota_stub.c for OTA symbol resolution
 test_main_src = files('../../tests/unit/test_main_linux.c')
 test_incs = include_directories('../../tests/unit')
+test_platform_src = files('ota_stub.c')
+
+if get_option('tool_script')
+    test_platform_src += files('scripting.c')
+endif
 
 rtclaw_test_exe = executable('rtclaw_test',
-    test_main_src + files('ota_stub.c'),
+    test_main_src + test_platform_src,
     include_directories: [claw_inc, claw_root_inc, test_incs],
-    c_args: platform_defs,
+    c_args: platform_c_args,
     link_with: [unittest_lib],
     dependencies: [rtclaw_dep, osal_dep, cjson_dep, thread_dep],
     install: false,

--- a/platform/linux/scripting.c
+++ b/platform/linux/scripting.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, Chao Liu <chao.liu.zevorn@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * Host Python bridge for Linux native platform.
+ */
+
+#include "platform/scripting.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define PYTHON3_BIN            "python3"
+#define SCRIPT_TEMPLATE        "/tmp/rtclaw-python-XXXXXX"
+#define SCRIPT_LANGUAGE_PYTHON "python"
+#define SCRIPT_LANGUAGE_MICROPYTHON "micropython"
+#define PIPE_READ_SIZE         128
+
+static int script_write_file(const char *code, char *path)
+{
+    size_t len = strlen(code);
+    ssize_t wrote = 0;
+    int fd;
+
+    snprintf(path, sizeof(SCRIPT_TEMPLATE), "%s", SCRIPT_TEMPLATE);
+    fd = mkstemp(path);
+    if (fd < 0) {
+        return -1;
+    }
+
+    while ((size_t)wrote < len) {
+        ssize_t ret = write(fd, code + wrote, len - (size_t)wrote);
+
+        if (ret < 0) {
+            close(fd);
+            unlink(path);
+            return -1;
+        }
+        wrote += ret;
+    }
+
+    close(fd);
+    return 0;
+}
+
+static void script_read_output(FILE *pipe, char *output, size_t output_size)
+{
+    char chunk[PIPE_READ_SIZE];
+    size_t len = 0;
+
+    if (output_size == 0) {
+        return;
+    }
+
+    output[0] = '\0';
+    while (!feof(pipe) && !ferror(pipe)) {
+        size_t n = fread(chunk, 1, sizeof(chunk), pipe);
+        size_t remain;
+        size_t copy;
+
+        if (n == 0) {
+            break;
+        }
+
+        if (len >= output_size - 1) {
+            continue;
+        }
+
+        remain = output_size - len - 1;
+        copy = n < remain ? n : remain;
+        memcpy(output + len, chunk, copy);
+        len += copy;
+        output[len] = '\0';
+    }
+}
+
+static int script_status_error(int status, char *output, size_t output_size)
+{
+    if (output_size == 0) {
+        return -1;
+    }
+
+    if (WIFEXITED(status)) {
+        snprintf(output, output_size,
+                 "python3 exited with status %d", WEXITSTATUS(status));
+    } else {
+        snprintf(output, output_size,
+                 "python3 terminated abnormally");
+    }
+
+    return -1;
+}
+
+int claw_platform_script_supported(const char *language)
+{
+    if (!language) {
+        return 0;
+    }
+
+    return strcmp(language, SCRIPT_LANGUAGE_PYTHON) == 0
+        || strcmp(language, SCRIPT_LANGUAGE_MICROPYTHON) == 0;
+}
+
+int claw_platform_run_script(const char *language, const char *code,
+                             char *output, size_t output_size)
+{
+    char path[] = SCRIPT_TEMPLATE;
+    char cmd[sizeof(path) + 32];
+    FILE *pipe;
+    int status;
+
+    if (!claw_platform_script_supported(language) || !code ||
+        !output || output_size == 0) {
+        return -1;
+    }
+
+    if (script_write_file(code, path) != 0) {
+        snprintf(output, output_size,
+                 "failed to create temporary script: %s",
+                 strerror(errno));
+        return -1;
+    }
+
+    snprintf(cmd, sizeof(cmd), PYTHON3_BIN " -I -B '%s' 2>&1", path);
+    pipe = popen(cmd, "r");
+    if (!pipe) {
+        unlink(path);
+        snprintf(output, output_size,
+                 "failed to launch python3: %s", strerror(errno));
+        return -1;
+    }
+
+    script_read_output(pipe, output, output_size);
+    status = pclose(pipe);
+    unlink(path);
+
+    if (status == -1) {
+        snprintf(output, output_size,
+                 "failed to wait for python3: %s", strerror(errno));
+        return -1;
+    }
+
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        if (output[0] == '\0') {
+            return script_status_error(status, output, output_size);
+        }
+        return -1;
+    }
+
+    return 0;
+}

--- a/platform/linux/shell.c
+++ b/platform/linux/shell.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <termios.h>
 #include <unistd.h>
+#include <errno.h>
 #include <sys/select.h>
 #include <sys/time.h>
 
@@ -175,14 +176,41 @@ static int shell_read_line(char *buf, int size)
     unsigned char ch;
 
     if (!isatty(STDIN_FILENO)) {
-        if (!fgets(buf, size, stdin)) {
-            return -1;
+        while (len < size - 1) {
+            fd_set readfds;
+            struct timeval timeout = { 0, 100000 };
+            int ret;
+
+            if (g_exit_flag) {
+                return -1;
+            }
+
+            FD_ZERO(&readfds);
+            FD_SET(STDIN_FILENO, &readfds);
+            ret = select(STDIN_FILENO + 1, &readfds, NULL, NULL, &timeout);
+            if (ret < 0) {
+                if (errno == EINTR) {
+                    continue;
+                }
+                return -1;
+            }
+            if (ret == 0) {
+                continue;
+            }
+
+            ret = (int)read(STDIN_FILENO, &ch, 1);
+            if (ret <= 0) {
+                if (len == 0) {
+                    return -1;
+                }
+                break;
+            }
+            if (ch == '\n' || ch == '\r') {
+                break;
+            }
+            buf[len++] = (char)ch;
         }
-        len = (int)strlen(buf);
-        while (len > 0 && (buf[len - 1] == '\n' ||
-                           buf[len - 1] == '\r')) {
-            buf[--len] = '\0';
-        }
+        buf[len] = '\0';
         return len;
     }
 

--- a/platform/vexpress-a9/SConscript
+++ b/platform/vexpress-a9/SConscript
@@ -3,9 +3,18 @@ from building import *
 
 cwd = GetCurrentDir()
 project_root = os.path.normpath(os.path.join(cwd, '..', '..'))
+micropython_root = os.path.join(
+    project_root, 'third_party', 'rtthread-micropython'
+)
 objs = []
 
 unit_test = os.environ.get('RTCLAW_UNIT_TEST', '0') == '1'
+
+AddDepend('PKG_USING_MICROPYTHON')
+Env.AppendUnique(CPPDEFINES=[
+    'PKG_USING_MICROPYTHON',
+    'PKG_MICROPYTHON_HEAP_SIZE=32768',
+])
 
 # --- Local subdirectories (drivers, applications) ---
 for d in os.listdir(cwd):
@@ -17,6 +26,64 @@ for d in os.listdir(cwd):
 board_src = [os.path.join(cwd, 'boards', 'qemu', 'board.c')]
 group = DefineGroup('Board', board_src, depend = [''],
     CPPPATH = [os.path.join(project_root, 'include')])
+objs = objs + group
+
+micropython_src = []
+micropython_src += Glob(os.path.join(micropython_root, 'py', '*.c'))
+micropython_src += Glob(os.path.join(
+    micropython_root, 'lib', 'mp-readline', '*.c'
+))
+micropython_src += Glob(os.path.join(micropython_root, 'lib', 'utils', '*.c'))
+micropython_src += Glob(os.path.join(micropython_root, 'extmod', '*.c'))
+micropython_src += [
+    src for src in Glob(os.path.join(micropython_root, 'port', '*.c'))
+    if os.path.basename(str(src)) not in ['mpy_main.c', 'mpputsnport.c']
+]
+micropython_src += Glob(os.path.join(
+    micropython_root, 'port', 'modules', '*.c'
+))
+micropython_src += Glob(os.path.join(
+    micropython_root, 'port', 'modules', 'machine', '*.c'
+))
+micropython_src += Glob(os.path.join(
+    micropython_root, 'port', 'modules', 'user', '*.c'
+))
+micropython_src += Glob(os.path.join(
+    micropython_root, 'lib', 'netutils', '*.c'
+))
+micropython_src += Glob(os.path.join(
+    micropython_root, 'lib', 'timeutils', '*.c'
+))
+micropython_src += Glob(os.path.join(
+    micropython_root, 'drivers', 'bus', '*.c'
+))
+micropython_src += Glob(os.path.join(
+    micropython_root, 'port', 'native', '*.c'
+))
+
+micropython_inc = [
+    micropython_root,
+    os.path.join(micropython_root, 'port'),
+    os.path.join(micropython_root, 'port', 'modules'),
+    os.path.join(micropython_root, 'port', 'modules', 'machine'),
+]
+group = DefineGroup('MicroPython', micropython_src,
+    depend = ['PKG_USING_MICROPYTHON'],
+    CPPPATH = micropython_inc,
+    LOCAL_CCFLAGS = ' -std=gnu99')
+objs = objs + group
+
+script_src = [
+    os.path.join(cwd, 'scripting.c'),
+    os.path.join(cwd, 'micropython_main.c'),
+    os.path.join(cwd, 'mpputsnport.c'),
+]
+script_inc = [
+    os.path.join(project_root, 'include'),
+    micropython_root,
+]
+group = DefineGroup('ClawScript', script_src, depend = [''],
+    CPPPATH = [os.path.abspath(p) for p in script_inc])
 objs = objs + group
 
 # rt-claw headers (unified include/ directory)

--- a/platform/vexpress-a9/micropython_main.c
+++ b/platform/vexpress-a9/micropython_main.c
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) 2026, Chao Liu <chao.liu.zevorn@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * Local MicroPython shell entry adapted for RT-Thread DFS v2.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+
+#include <rtthread.h>
+
+#ifdef RT_USING_DFS
+#include <unistd.h>
+#include <fcntl.h>
+#include <dfs.h>
+#endif
+
+#include "py/compile.h"
+#include "py/frozenmod.h"
+#include "py/gc.h"
+#include "py/mperrno.h"
+#include "py/mpthread.h"
+#include "py/repl.h"
+#include "py/runtime.h"
+#include "py/stackctrl.h"
+#include "lib/mp-readline/readline.h"
+#include "lib/utils/pyexec.h"
+#include "mpgetcharport.h"
+#include "mpputsnport.h"
+
+#define THREAD_STACK_NO_SYNC   4096
+#define THREAD_STACK_WITH_SYNC 8192
+
+#if MICROPY_ENABLE_COMPILER
+void do_str(const char *src, mp_parse_input_kind_t input_kind)
+{
+    nlr_buf_t nlr;
+
+    if (nlr_push(&nlr) == 0) {
+        mp_lexer_t *lex = mp_lexer_new_from_str_len(
+            MP_QSTR__lt_stdin_gt_,
+            src,
+            strlen(src),
+            0
+        );
+        qstr source_name = lex->source_name;
+        mp_parse_tree_t parse_tree = mp_parse(lex, input_kind);
+        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, true);
+
+        mp_call_function_0(module_fun);
+        nlr_pop();
+    } else {
+        mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
+    }
+}
+#endif
+
+#ifdef RT_USING_DFS
+static int mp_sys_resource_bak(struct dfs_fdtable **table_bak)
+{
+    struct dfs_fdtable *fd_table;
+    struct dfs_fdtable *fd_table_bak;
+    struct dfs_file **fds;
+
+    fd_table = dfs_fdtable_get();
+    if (!fd_table) {
+        return RT_FALSE;
+    }
+
+    fd_table_bak = (struct dfs_fdtable *)rt_malloc(
+        sizeof(struct dfs_fdtable)
+    );
+    if (!fd_table_bak) {
+        return RT_FALSE;
+    }
+
+    fds = (struct dfs_file **)rt_malloc(
+        (int)fd_table->maxfd * sizeof(struct dfs_file *)
+    );
+    if (!fds) {
+        rt_free(fd_table_bak);
+        return RT_FALSE;
+    }
+
+    rt_memcpy(fds, fd_table->fds,
+              (int)fd_table->maxfd * sizeof(struct dfs_file *));
+    fd_table_bak->maxfd = (int)fd_table->maxfd;
+    fd_table_bak->fds = fds;
+    *table_bak = fd_table_bak;
+
+    return RT_TRUE;
+}
+
+static void mp_sys_resource_gc(struct dfs_fdtable *fd_table_bak)
+{
+    struct dfs_fdtable *fd_table;
+    int i;
+
+    if (!fd_table_bak) {
+        return;
+    }
+
+    fd_table = dfs_fdtable_get();
+    if (!fd_table) {
+        rt_free(fd_table_bak->fds);
+        rt_free(fd_table_bak);
+        return;
+    }
+
+    for (i = 0; i < (int)fd_table->maxfd; i++) {
+        if (fd_table->fds[i] != RT_NULL) {
+            if ((i < (int)fd_table_bak->maxfd &&
+                 fd_table_bak->fds[i] == RT_NULL) ||
+                i >= (int)fd_table_bak->maxfd) {
+                close(i + DFS_STDIO_OFFSET);
+            }
+        }
+    }
+
+    rt_free(fd_table_bak->fds);
+    rt_free(fd_table_bak);
+}
+#endif
+
+static void *stack_top = RT_NULL;
+static char *heap = RT_NULL;
+
+void mpy_main(const char *filename)
+{
+    int stack_dummy;
+    int stack_size_check;
+
+#ifdef RT_USING_DFS
+    struct dfs_fdtable *fd_table_bak = RT_NULL;
+#endif
+
+    stack_top = (void *)&stack_dummy;
+
+#ifdef RT_USING_DFS
+    mp_sys_resource_bak(&fd_table_bak);
+#endif
+
+    mp_getchar_init();
+    mp_putsn_init();
+
+#if defined(MICROPYTHON_USING_FILE_SYNC_VIA_IDE)
+    stack_size_check = THREAD_STACK_WITH_SYNC;
+#else
+    stack_size_check = THREAD_STACK_NO_SYNC;
+#endif
+
+    if (rt_thread_self()->stack_size < stack_size_check) {
+#if (RTTHREAD_VERSION < RT_VERSION_CHECK(5, 0, 1))
+        mp_printf(&mp_plat_print,
+                  "The stack (%.*s) size for executing "
+                  "MicroPython must be >= %d\n",
+                  RT_NAME_MAX, rt_thread_self()->name,
+                  stack_size_check);
+#else
+        mp_printf(&mp_plat_print,
+                  "The stack (%.*s) size for executing "
+                  "MicroPython must be >= %d\n",
+                  RT_NAME_MAX, rt_thread_self()->parent.name,
+                  stack_size_check);
+#endif
+    }
+
+#if MICROPY_PY_THREAD
+    mp_thread_init(
+        rt_thread_self()->stack_addr,
+        ((rt_uint32_t)stack_top
+         - (rt_uint32_t)rt_thread_self()->stack_addr) / 4
+    );
+#endif
+
+    mp_stack_set_top(stack_top);
+    mp_stack_set_limit(rt_thread_self()->stack_size - 1024);
+
+#if MICROPY_ENABLE_GC
+    heap = rt_malloc(MICROPY_HEAP_SIZE);
+    if (!heap) {
+        mp_printf(&mp_plat_print, "No memory for MicroPython Heap!\n");
+        goto cleanup;
+    }
+    gc_init(heap, heap + MICROPY_HEAP_SIZE);
+#endif
+
+    mp_init();
+
+    mp_obj_list_init(mp_sys_path, 0);
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_));
+    mp_obj_list_append(
+        mp_sys_path,
+        mp_obj_new_str(MICROPY_PY_PATH_FIRST,
+                       strlen(MICROPY_PY_PATH_FIRST))
+    );
+    mp_obj_list_append(
+        mp_sys_path,
+        mp_obj_new_str(MICROPY_PY_PATH_SECOND,
+                       strlen(MICROPY_PY_PATH_SECOND))
+    );
+    mp_obj_list_init(mp_sys_argv, 0);
+    readline_init0();
+
+    if (filename) {
+#ifndef MICROPYTHON_USING_UOS
+        mp_printf(&mp_plat_print,
+                  "Please enable uos module in sys module option first.\n");
+#else
+        pyexec_file(filename);
+#endif
+    } else {
+#ifdef MICROPYTHON_USING_UOS
+        void *frozen_data;
+        const char *_boot_file = "_boot.py";
+        const char *boot_file = "boot.py";
+        const char *main_file = MICROPY_MAIN_PY_PATH;
+
+        if (mp_find_frozen_module(_boot_file, strlen(_boot_file),
+                                  &frozen_data) != MP_FROZEN_NONE) {
+            pyexec_frozen_module(_boot_file);
+        }
+        if (!access(boot_file, 0)) {
+            pyexec_file(boot_file);
+        }
+        if (!access(main_file, 0) &&
+            pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
+            pyexec_file(main_file);
+        }
+#endif
+
+        mp_printf(&mp_plat_print, "\n");
+        for (;;) {
+            if (pyexec_mode_kind == PYEXEC_MODE_RAW_REPL) {
+                if (pyexec_raw_repl() != 0) {
+                    break;
+                }
+            } else {
+                if (pyexec_friendly_repl() != 0) {
+                    break;
+                }
+            }
+        }
+    }
+
+    gc_sweep_all();
+    mp_deinit();
+
+cleanup:
+#if MICROPY_PY_THREAD
+    mp_thread_deinit();
+#endif
+
+#if MICROPY_ENABLE_GC
+    if (heap) {
+        rt_free(heap);
+        heap = RT_NULL;
+    }
+#endif
+
+    mp_putsn_deinit();
+    mp_getchar_deinit();
+
+#ifdef RT_USING_DFS
+    mp_sys_resource_gc(fd_table_bak);
+#endif
+}
+
+#if !MICROPY_PY_MODUOS_FILE
+mp_import_stat_t mp_import_stat(const char *path)
+{
+    (void)path;
+    return MP_IMPORT_STAT_NO_EXIST;
+}
+#endif
+
+NORETURN void nlr_jump_fail(void *val)
+{
+    (void)val;
+    mp_printf(MICROPY_ERROR_PRINTER, "nlr_jump_fail\n");
+    while (1) {
+    }
+}
+
+#ifndef NDEBUG
+NORETURN void MP_WEAK __assert_func(const char *file, int line,
+                                    const char *func,
+                                    const char *expr)
+{
+    (void)func;
+    mp_printf(MICROPY_ERROR_PRINTER,
+              "Assertion '%s' failed, at file %s:%d\n",
+              expr, file, line);
+    while (1) {
+    }
+}
+#endif
+
+int DEBUG_printf(const char *format, ...)
+{
+    static char log_buf[512];
+    va_list args;
+
+    va_start(args, format);
+    rt_vsprintf(log_buf, format, args);
+    mp_printf(&mp_plat_print, "%s", log_buf);
+    va_end(args);
+
+    return 0;
+}
+
+#ifndef MICROPYTHON_USING_UOS
+mp_lexer_t *mp_lexer_new_from_file(const char *filename)
+{
+    (void)filename;
+    mp_raise_OSError(MP_ENOENT);
+}
+#endif
+
+#if defined(RT_USING_FINSH) && defined(FINSH_USING_MSH)
+#include <finsh.h>
+static void python(uint8_t argc, char **argv)
+{
+    if (argc > 1) {
+        mpy_main(argv[1]);
+    } else {
+        mpy_main(RT_NULL);
+    }
+}
+MSH_CMD_EXPORT(python, MicroPython: `python [file.py]` execute python script);
+#endif

--- a/platform/vexpress-a9/mpputsnport.c
+++ b/platform/vexpress-a9/mpputsnport.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, Chao Liu <chao.liu.zevorn@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * Local MicroPython output bridge for RT-Thread.
+ */
+
+#include <rtdevice.h>
+#include <rtthread.h>
+
+#include "mpputsnport.h"
+
+static rt_device_t s_console_dev = RT_NULL;
+static rt_uint16_t s_console_open_flag;
+
+void mp_putsn(const char *str, size_t len)
+{
+    if (s_console_dev) {
+        rt_device_write(s_console_dev, 0, str, len);
+    }
+}
+
+void mp_putsn_stream(const char *str, size_t len)
+{
+    if (s_console_dev) {
+        rt_uint16_t old_flag = s_console_dev->open_flag;
+
+        s_console_dev->open_flag |= RT_DEVICE_FLAG_STREAM;
+        rt_device_write(s_console_dev, 0, str, len);
+        s_console_dev->open_flag = old_flag;
+    }
+}
+
+void mp_putsn_init(void)
+{
+    s_console_dev = rt_console_get_device();
+    if (s_console_dev) {
+        s_console_open_flag = s_console_dev->open_flag;
+    }
+}
+
+void mp_putsn_deinit(void)
+{
+    if (s_console_dev) {
+        s_console_dev->open_flag = s_console_open_flag;
+        s_console_dev = RT_NULL;
+    }
+}

--- a/platform/vexpress-a9/scripting.c
+++ b/platform/vexpress-a9/scripting.c
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2026, Chao Liu <chao.liu.zevorn@gmail.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * MicroPython bridge for vexpress-a9 / RT-Thread.
+ */
+
+#include "platform/scripting.h"
+
+#include <rtdevice.h>
+#include <rtthread.h>
+#include <string.h>
+
+#include "py/compile.h"
+#include "py/gc.h"
+#include "py/mpthread.h"
+#include "py/runtime.h"
+#include "py/stackctrl.h"
+#include "port/mpconfigport.h"
+#include "port/mpputsnport.h"
+
+#define CAPTURE_NAME_LEN 16
+#define MICROPY_STACK_MIN 4096
+#define MICROPYTHON_LANG "micropython"
+
+struct script_capture_device {
+    struct rt_device parent;
+    char            *buffer;
+    size_t           size;
+    size_t           len;
+};
+
+static rt_mutex_t s_script_lock = RT_NULL;
+static rt_uint32_t s_capture_seq;
+
+static rt_err_t capture_open(rt_device_t dev, rt_uint16_t oflag)
+{
+    (void)dev;
+    (void)oflag;
+    return RT_EOK;
+}
+
+static rt_err_t capture_close(rt_device_t dev)
+{
+    (void)dev;
+    return RT_EOK;
+}
+
+static rt_ssize_t capture_read(rt_device_t dev, rt_off_t pos,
+                               void *buffer, rt_size_t size)
+{
+    (void)dev;
+    (void)pos;
+    (void)buffer;
+    (void)size;
+    return 0;
+}
+
+static rt_ssize_t capture_write(rt_device_t dev, rt_off_t pos,
+                                const void *buffer, rt_size_t size)
+{
+    struct script_capture_device *capture;
+    size_t avail;
+    size_t copy;
+
+    (void)pos;
+    capture = (struct script_capture_device *)dev;
+    if (!capture->buffer || capture->size == 0) {
+        return size;
+    }
+
+    if (capture->len >= capture->size - 1) {
+        return size;
+    }
+
+    avail = capture->size - capture->len - 1;
+    copy = size < avail ? size : avail;
+    if (copy > 0) {
+        rt_memcpy(capture->buffer + capture->len, buffer, copy);
+        capture->len += copy;
+        capture->buffer[capture->len] = '\0';
+    }
+
+    return size;
+}
+
+static rt_err_t capture_control(rt_device_t dev, int cmd, void *args)
+{
+    (void)dev;
+    (void)cmd;
+    (void)args;
+    return RT_EOK;
+}
+
+#ifdef RT_USING_DEVICE_OPS
+static const struct rt_device_ops s_capture_ops = {
+    .init = RT_NULL,
+    .open = capture_open,
+    .close = capture_close,
+    .read = capture_read,
+    .write = capture_write,
+    .control = capture_control,
+};
+#endif
+
+static rt_mutex_t get_script_lock(void)
+{
+    if (s_script_lock == RT_NULL) {
+        s_script_lock = rt_mutex_create("mpy_lock", RT_IPC_FLAG_PRIO);
+    }
+
+    return s_script_lock;
+}
+
+static int micropython_exec_string(const char *code)
+{
+    nlr_buf_t nlr;
+
+    if (nlr_push(&nlr) == 0) {
+        mp_lexer_t *lexer = mp_lexer_new_from_str_len(
+            MP_QSTR__lt_stdin_gt_,
+            code,
+            strlen(code),
+            0
+        );
+        qstr source_name = lexer->source_name;
+        mp_parse_tree_t parse_tree = mp_parse(lexer, MP_PARSE_FILE_INPUT);
+        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, true);
+
+        mp_call_function_0(module_fun);
+        nlr_pop();
+        return 0;
+    }
+
+    mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
+    return -1;
+}
+
+static int micropython_run(const char *code)
+{
+    int stack_dummy;
+    void *stack_top = (void *)&stack_dummy;
+    char *heap = RT_NULL;
+    int rc;
+
+    if (rt_thread_self()->stack_size < MICROPY_STACK_MIN) {
+        static const char msg[] =
+            "MicroPython requires at least 4096 bytes of stack.\n";
+
+        mp_putsn(msg, sizeof(msg) - 1);
+        return -1;
+    }
+
+#if MICROPY_PY_THREAD
+    mp_thread_init(
+        rt_thread_self()->stack_addr,
+        ((rt_uint32_t)stack_top
+         - (rt_uint32_t)rt_thread_self()->stack_addr) / 4
+    );
+#endif
+
+    mp_stack_set_top(stack_top);
+    mp_stack_set_limit(rt_thread_self()->stack_size - 1024);
+
+#if MICROPY_ENABLE_GC
+    heap = rt_malloc(MICROPY_HEAP_SIZE);
+    if (!heap) {
+        static const char msg[] =
+            "No memory for MicroPython heap.\n";
+
+        mp_putsn(msg, sizeof(msg) - 1);
+        return -1;
+    }
+    gc_init(heap, heap + MICROPY_HEAP_SIZE);
+#endif
+
+    mp_init();
+    mp_obj_list_init(mp_sys_path, 0);
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_));
+    mp_obj_list_append(
+        mp_sys_path,
+        mp_obj_new_str(MICROPY_PY_PATH_FIRST,
+                       strlen(MICROPY_PY_PATH_FIRST))
+    );
+    mp_obj_list_append(
+        mp_sys_path,
+        mp_obj_new_str(MICROPY_PY_PATH_SECOND,
+                       strlen(MICROPY_PY_PATH_SECOND))
+    );
+    mp_obj_list_init(mp_sys_argv, 0);
+
+    rc = micropython_exec_string(code);
+
+    gc_sweep_all();
+    mp_deinit();
+
+#if MICROPY_PY_THREAD
+    mp_thread_deinit();
+#endif
+
+#if MICROPY_ENABLE_GC
+    rt_free(heap);
+#endif
+
+    return rc;
+}
+
+int claw_platform_script_supported(const char *language)
+{
+    if (!language) {
+        return 0;
+    }
+
+    return strcmp(language, MICROPYTHON_LANG) == 0;
+}
+
+int claw_platform_run_script(const char *language, const char *code,
+                             char *output, size_t output_size)
+{
+    struct script_capture_device capture;
+    char capture_name[CAPTURE_NAME_LEN];
+    rt_device_t old_console;
+    rt_mutex_t lock;
+    int rc = -1;
+
+    if (!claw_platform_script_supported(language) || !code ||
+        !output || output_size == 0) {
+        return -1;
+    }
+
+    lock = get_script_lock();
+    if (lock == RT_NULL) {
+        rt_snprintf(output, output_size,
+                    "failed to create script lock");
+        return -1;
+    }
+
+    if (rt_mutex_take(lock, RT_WAITING_FOREVER) != RT_EOK) {
+        rt_snprintf(output, output_size,
+                    "failed to acquire script lock");
+        return -1;
+    }
+
+    output[0] = '\0';
+    old_console = rt_console_get_device();
+    if (old_console == RT_NULL) {
+        rt_snprintf(output, output_size,
+                    "console device is not available");
+        goto out_unlock;
+    }
+
+    rt_memset(&capture, 0, sizeof(capture));
+    capture.parent.type = RT_Device_Class_Char;
+#ifdef RT_USING_DEVICE_OPS
+    capture.parent.ops = &s_capture_ops;
+#else
+    capture.parent.open = capture_open;
+    capture.parent.close = capture_close;
+    capture.parent.read = capture_read;
+    capture.parent.write = capture_write;
+    capture.parent.control = capture_control;
+#endif
+    capture.buffer = output;
+    capture.size = output_size;
+
+    s_capture_seq++;
+    rt_snprintf(capture_name, sizeof(capture_name),
+                "mpcap%lu", (unsigned long)s_capture_seq);
+
+    if (rt_device_register(&capture.parent, capture_name,
+                           RT_DEVICE_FLAG_RDWR) != RT_EOK) {
+        rt_snprintf(output, output_size,
+                    "failed to register capture console");
+        goto out_unlock;
+    }
+
+    if (rt_console_set_device(capture_name) == RT_NULL) {
+        rt_snprintf(output, output_size,
+                    "failed to switch console");
+        rt_device_unregister(&capture.parent);
+        goto out_unlock;
+    }
+
+    mp_putsn_init();
+    rc = micropython_run(code);
+    mp_putsn_deinit();
+
+    rt_console_set_device(old_console->parent.name);
+    rt_device_unregister(&capture.parent);
+
+out_unlock:
+    rt_mutex_release(lock);
+    return rc;
+}

--- a/tests/functional/rtclaw_test/cmd.py
+++ b/tests/functional/rtclaw_test/cmd.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Console buffer and interaction functions for QEMU subprocess I/O.
 
+import os
 import re
 import threading
 import time
@@ -23,7 +24,7 @@ class ConsoleBuffer:
 
     def __init__(self, proc):
         self.proc = proc
-        self._lines = []
+        self._output = ""
         self._lock = threading.Lock()
         self._closed = False
         self._reader = threading.Thread(
@@ -33,10 +34,14 @@ class ConsoleBuffer:
 
     def _read_loop(self):
         try:
-            for raw in self.proc.stdout:
-                line = _strip_ansi(raw.decode("utf-8", errors="replace"))
+            fd = self.proc.stdout.fileno()
+            while True:
+                raw = os.read(fd, 256)
+                if not raw:
+                    break
+                text = _strip_ansi(raw.decode("utf-8", errors="replace"))
                 with self._lock:
-                    self._lines.append(line)
+                    self._output += text
         except (ValueError, OSError):
             pass
         finally:
@@ -45,10 +50,11 @@ class ConsoleBuffer:
 
     def get_lines(self):
         with self._lock:
-            return list(self._lines)
+            return self._output.splitlines(keepends=True)
 
     def get_output(self):
-        return "".join(self.get_lines())
+        with self._lock:
+            return self._output
 
     @property
     def is_alive(self):
@@ -62,7 +68,8 @@ class ConsoleBuffer:
 
 def wait_for_console_pattern(console: ConsoleBuffer,
                              pattern: str,
-                             timeout: float = 60.0) -> str:
+                             timeout: float = 60.0,
+                             start_offset: int = 0) -> str:
     """
     Wait until `pattern` appears in console output.
 
@@ -71,21 +78,29 @@ def wait_for_console_pattern(console: ConsoleBuffer,
     Raises RuntimeError if QEMU exits before pattern is found.
     """
     deadline = time.monotonic() + timeout
-    seen = 0
+    settle_deadline = 0.0
+    matched_len = -1
 
     while True:
-        lines = console.get_lines()
+        output = console.get_output()
+        pos = output.find(pattern, start_offset)
+        if pos >= 0:
+            end = pos + len(pattern)
+            newline = output.find("\n", end)
 
-        for i in range(seen, len(lines)):
-            if pattern in lines[i]:
-                return "".join(lines[:i + 1])
-        seen = len(lines)
+            if newline >= 0:
+                return output[:newline + 1]
+
+            if len(output) != matched_len:
+                matched_len = len(output)
+                settle_deadline = time.monotonic() + 0.2
+            elif time.monotonic() >= settle_deadline:
+                return output
 
         if time.monotonic() >= deadline:
-            output = console.get_output()
             raise TimeoutError(
                 f"Pattern {pattern!r} not found within {timeout}s.\n"
-                f"--- Console output ({len(lines)} lines) ---\n"
+                f"--- Console output ({len(output.splitlines())} lines) ---\n"
                 f"{output[-2000:]}"
             )
 
@@ -111,5 +126,6 @@ def exec_command_and_wait_for_pattern(console: ConsoleBuffer,
                                       pattern: str,
                                       timeout: float = 30.0) -> str:
     """Send a command and wait for a pattern in the output."""
+    start_offset = len(console.get_output())
     exec_command(console, command)
-    return wait_for_console_pattern(console, pattern, timeout)
+    return wait_for_console_pattern(console, pattern, timeout, start_offset)

--- a/tests/functional/test_linux_kv.py
+++ b/tests/functional/test_linux_kv.py
@@ -17,7 +17,7 @@ class TestLinuxKvPersistence(RTClawLinuxTest):
         exec_command_and_wait_for_pattern(
             self.console, "/remember persist_key persist_value",
             "Remembered:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
 
         self.restart()
@@ -25,7 +25,7 @@ class TestLinuxKvPersistence(RTClawLinuxTest):
 
         output = exec_command_and_wait_for_pattern(
             self.console, "/memories", "persist_key",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("persist_key", output)
         self.assertIn("persist_value", output)
@@ -37,12 +37,12 @@ class TestLinuxKvPersistence(RTClawLinuxTest):
         exec_command_and_wait_for_pattern(
             self.console, "/remember alpha first_val",
             "Remembered:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         exec_command_and_wait_for_pattern(
             self.console, "/remember beta second_val",
             "Remembered:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
 
         self.restart()
@@ -50,13 +50,13 @@ class TestLinuxKvPersistence(RTClawLinuxTest):
 
         output = exec_command_and_wait_for_pattern(
             self.console, "/memories", "alpha",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("alpha", output)
 
         output = exec_command_and_wait_for_pattern(
             self.console, "/memories", "beta",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("beta", output)
 
@@ -67,11 +67,11 @@ class TestLinuxKvPersistence(RTClawLinuxTest):
         exec_command_and_wait_for_pattern(
             self.console, "/remember temp_key temp_val",
             "Remembered:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         exec_command_and_wait_for_pattern(
             self.console, "/forget temp_key", "Forgot:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
 
         self.restart()
@@ -79,7 +79,7 @@ class TestLinuxKvPersistence(RTClawLinuxTest):
 
         output = exec_command_and_wait_for_pattern(
             self.console, "/memories", "0/16 entries",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertNotIn("temp_key", output)
 
@@ -91,7 +91,7 @@ class TestLinuxKvPersistence(RTClawLinuxTest):
             self.console,
             "/ai_set model persistent-model-42",
             "Model saved:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
 
         self.restart()
@@ -99,6 +99,6 @@ class TestLinuxKvPersistence(RTClawLinuxTest):
 
         output = exec_command_and_wait_for_pattern(
             self.console, "/ai_status", "Model:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("persistent-model-42", output)

--- a/tests/functional/test_linux_python.py
+++ b/tests/functional/test_linux_python.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+# Python command tests for Linux native platform.
+
+from rtclaw_test import (
+    RTClawLinuxTest,
+    exec_command_and_wait_for_pattern,
+)
+
+
+class TestLinuxPython(RTClawLinuxTest):
+    """Test direct Python execution on Linux native platform."""
+
+    def setUp(self):
+        super().setUp()
+        self.wait_for_shell_prompt()
+
+    def test_python_command_executes_code(self):
+        """'/python' must execute a simple expression."""
+        output = exec_command_and_wait_for_pattern(
+            self.console, "/python print(40 + 2)", "42",
+            timeout=self.platform.shell_timeout,
+        )
+        self.assertIn("42", output)

--- a/tests/functional/test_linux_shell.py
+++ b/tests/functional/test_linux_shell.py
@@ -19,7 +19,7 @@ class TestLinuxShell(RTClawLinuxTest):
         output = exec_command_and_wait_for_pattern(
             self.console, "/help",
             "Anything else is sent directly to AI.",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("/help", output)
         self.assertIn("/log", output)
@@ -30,7 +30,7 @@ class TestLinuxShell(RTClawLinuxTest):
         """'/log off' must disable log output."""
         output = exec_command_and_wait_for_pattern(
             self.console, "/log off", "Log output: OFF",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("OFF", output)
 
@@ -38,7 +38,7 @@ class TestLinuxShell(RTClawLinuxTest):
         """'/log on' must enable log output."""
         output = exec_command_and_wait_for_pattern(
             self.console, "/log on", "Log output: ON",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("ON", output)
 
@@ -46,7 +46,7 @@ class TestLinuxShell(RTClawLinuxTest):
         """'/log level debug' must set log level."""
         output = exec_command_and_wait_for_pattern(
             self.console, "/log level debug", "Log level: debug",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("debug", output)
 
@@ -54,7 +54,7 @@ class TestLinuxShell(RTClawLinuxTest):
         """'/log level error' must set log level."""
         output = exec_command_and_wait_for_pattern(
             self.console, "/log level error", "Log level: error",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("error", output)
 
@@ -62,7 +62,7 @@ class TestLinuxShell(RTClawLinuxTest):
         """'/history' must show 0 messages initially."""
         output = exec_command_and_wait_for_pattern(
             self.console, "/history", "messages",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("0 messages", output)
 
@@ -70,7 +70,7 @@ class TestLinuxShell(RTClawLinuxTest):
         """'/clear' must clear conversation memory."""
         output = exec_command_and_wait_for_pattern(
             self.console, "/clear", "cleared",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("cleared", output)
 
@@ -79,11 +79,11 @@ class TestLinuxShell(RTClawLinuxTest):
         exec_command_and_wait_for_pattern(
             self.console, "/remember mykey myvalue",
             "Remembered:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         output = exec_command_and_wait_for_pattern(
             self.console, "/memories", "mykey",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("mykey", output)
 
@@ -92,11 +92,11 @@ class TestLinuxShell(RTClawLinuxTest):
         exec_command_and_wait_for_pattern(
             self.console, "/remember forgetme tempval",
             "Remembered:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         output = exec_command_and_wait_for_pattern(
             self.console, "/forget forgetme", "Forgot:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("forgetme", output)
 
@@ -104,7 +104,7 @@ class TestLinuxShell(RTClawLinuxTest):
         """'/ai_status' must show Model field."""
         output = exec_command_and_wait_for_pattern(
             self.console, "/ai_status", "Model:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("Model:", output)
         self.assertIn("API URL:", output)
@@ -114,12 +114,12 @@ class TestLinuxShell(RTClawLinuxTest):
         output = exec_command_and_wait_for_pattern(
             self.console, "/ai_set model test-model-123",
             "Model saved:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("test-model-123", output)
         output = exec_command_and_wait_for_pattern(
             self.console, "/ai_status", "Model:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("test-model-123", output)
 
@@ -128,7 +128,7 @@ class TestLinuxShell(RTClawLinuxTest):
         output = exec_command_and_wait_for_pattern(
             self.console, "/ai_set url https://test.example.com/v1",
             "API URL saved:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("https://test.example.com/v1", output)
 
@@ -136,7 +136,7 @@ class TestLinuxShell(RTClawLinuxTest):
         """'/ip' must show network info."""
         output = exec_command_and_wait_for_pattern(
             self.console, "/ip", "Network:",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("Network:", output)
 
@@ -144,7 +144,7 @@ class TestLinuxShell(RTClawLinuxTest):
         """Unknown /command must show error message."""
         output = exec_command_and_wait_for_pattern(
             self.console, "/nonexistent_cmd_xyz", "Unknown command",
-            timeout=self.SHELL_TIMEOUT,
+            timeout=self.platform.shell_timeout,
         )
         self.assertIn("Unknown command", output)
 

--- a/tests/functional/test_vexpress_micropython.py
+++ b/tests/functional/test_vexpress_micropython.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+# MicroPython smoke test for the RT-Thread vexpress-a9 platform.
+
+import os
+import time
+import unittest
+
+from rtclaw_test import (
+    RTClawQemuTest,
+    exec_command_and_wait_for_pattern,
+    wait_for_console_pattern,
+)
+
+
+@unittest.skipUnless(
+    os.environ.get("RTCLAW_TEST_PLATFORM", "esp32c3-qemu")
+    == "vexpress-a9-qemu",
+    "MicroPython smoke test requires vexpress-a9-qemu",
+)
+class TestVexpressMicroPython(RTClawQemuTest):
+    """Verify the RT-Thread MicroPython REPL starts and executes code."""
+
+    def setUp(self):
+        super().setUp()
+        wait_for_console_pattern(
+            self.console, "msh />", timeout=self.platform.boot_timeout
+        )
+
+    def test_python_repl_executes_code(self):
+        """The python shell must execute a simple expression."""
+        output = exec_command_and_wait_for_pattern(
+            self.console,
+            "python",
+            ">>> ",
+            timeout=self.platform.shell_timeout,
+        )
+        self.assertIn("MicroPython", output)
+        self.assertIn(">>> ", output)
+        time.sleep(1.0)
+
+        start_offset = len(self.console.get_output())
+        self.console.send("print(40 + 2)\r")
+        output = wait_for_console_pattern(
+            self.console,
+            "42",
+            timeout=self.platform.shell_timeout,
+            start_offset=start_offset,
+        )
+        self.assertIn("42", output)

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -6,6 +6,7 @@ unit_test_src = files(
     'test_ai_memory.c',
     'test_gateway.c',
     'test_tools.c',
+    'test_script_tool.c',
     'test_im_util.c',
 )
 

--- a/tests/unit/run.py
+++ b/tests/unit/run.py
@@ -20,16 +20,18 @@ def build():
     env = os.environ.copy()
     env["RTCLAW_UNIT_TEST"] = "1"
 
-    # Ensure Meson is set up with OTA enabled (stubs in test_ota.c)
+    # Ensure Meson is set up with OTA and script tool enabled.
     if not os.path.isfile(os.path.join(BUILD_DIR, "build.ninja")):
         subprocess.check_call(
             ["meson", "setup", BUILD_DIR,
-             "--cross-file", cross_file, "-Dota=true"],
+             "--cross-file", cross_file,
+             "-Dota=true", "-Dtool_script=true"],
             cwd=PROJECT_ROOT, env=env,
         )
     else:
         subprocess.check_call(
-            ["meson", "configure", BUILD_DIR, "-Dota=true"],
+            ["meson", "configure", BUILD_DIR,
+             "-Dota=true", "-Dtool_script=true"],
             cwd=PROJECT_ROOT, env=env,
         )
 

--- a/tests/unit/test_runner.c
+++ b/tests/unit/test_runner.c
@@ -11,6 +11,7 @@
 extern int test_ai_memory_suite(void);
 extern int test_gateway_suite(void);
 extern int test_tools_suite(void);
+extern int test_script_tool_suite(void);
 extern int test_im_util_suite(void);
 extern int test_ota_suite(void);
 extern int test_ai_skill_suite(void);
@@ -24,6 +25,7 @@ int run_all_unit_tests(void)
     failed += test_ai_memory_suite();
     failed += test_gateway_suite();
     failed += test_tools_suite();
+    failed += test_script_tool_suite();
     failed += test_im_util_suite();
     failed += test_ota_suite();
     failed += test_ai_skill_suite();

--- a/tests/unit/test_script_tool.c
+++ b/tests/unit/test_script_tool.c
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Unit tests for the run_script tool.
+ */
+
+#include "framework/test.h"
+#include "claw/core/tool.h"
+#include "claw/services/tools/tools.h"
+#include "cJSON.h"
+
+#include <stdio.h>
+
+static void test_run_script_tool_registered(void)
+{
+    claw_tool_core_collect_from_section();
+    TEST_ASSERT_EQ(claw_tools_init(), CLAW_OK);
+    TEST_ASSERT_NOT_NULL(claw_tool_find("run_script"));
+}
+
+static void test_run_script_tool_executes_code(void)
+{
+    const struct claw_tool *tool = claw_tool_find("run_script");
+    cJSON *params;
+    cJSON *result;
+    cJSON *status;
+    cJSON *output;
+
+    TEST_ASSERT_NOT_NULL(tool);
+
+    params = cJSON_CreateObject();
+    TEST_ASSERT_NOT_NULL(params);
+    cJSON_AddStringToObject(params, "code", "print(40 + 2)");
+
+    result = cJSON_CreateObject();
+    TEST_ASSERT_NOT_NULL(result);
+
+    TEST_ASSERT_EQ(
+        claw_tool_invoke((struct claw_tool *)tool, params, result),
+        CLAW_OK
+    );
+
+    status = cJSON_GetObjectItem(result, "status");
+    output = cJSON_GetObjectItem(result, "output");
+    TEST_ASSERT_NOT_NULL(status);
+    TEST_ASSERT_NOT_NULL(output);
+    TEST_ASSERT_STR_EQ(status->valuestring, "ok");
+    TEST_ASSERT(strstr(output->valuestring, "42") != NULL);
+
+    cJSON_Delete(result);
+    cJSON_Delete(params);
+}
+
+#ifdef CLAW_PLATFORM_LINUX
+static void test_run_script_tool_executes_python(void)
+{
+    const struct claw_tool *tool = claw_tool_find("run_script");
+    cJSON *params;
+    cJSON *result;
+    cJSON *status;
+    cJSON *output;
+
+    TEST_ASSERT_NOT_NULL(tool);
+
+    params = cJSON_CreateObject();
+    TEST_ASSERT_NOT_NULL(params);
+    cJSON_AddStringToObject(params, "language", "python");
+    cJSON_AddStringToObject(params, "code", "print(40 + 2)");
+
+    result = cJSON_CreateObject();
+    TEST_ASSERT_NOT_NULL(result);
+
+    TEST_ASSERT_EQ(
+        claw_tool_invoke((struct claw_tool *)tool, params, result),
+        CLAW_OK
+    );
+
+    status = cJSON_GetObjectItem(result, "status");
+    output = cJSON_GetObjectItem(result, "output");
+    TEST_ASSERT_NOT_NULL(status);
+    TEST_ASSERT_NOT_NULL(output);
+    TEST_ASSERT_STR_EQ(status->valuestring, "ok");
+    TEST_ASSERT(strstr(output->valuestring, "42") != NULL);
+
+    cJSON_Delete(result);
+    cJSON_Delete(params);
+}
+#endif
+
+int test_script_tool_suite(void)
+{
+    printf("=== test_script_tool ===\n");
+    TEST_BEGIN();
+
+    RUN_TEST(test_run_script_tool_registered);
+    RUN_TEST(test_run_script_tool_executes_code);
+#ifdef CLAW_PLATFORM_LINUX
+    RUN_TEST(test_run_script_tool_executes_python);
+#endif
+
+    TEST_END();
+}


### PR DESCRIPTION
## Summary
- add the `run_script` tool and platform scripting hooks
- enable RT-Thread vexpress-a9-qemu to execute MicroPython and include it in `test-smoke-vexpress`
- enable Linux native to execute host `python3`, add `/python`, and add unit/functional coverage

## Test Plan
- [x] `make test-unit-linux`
- [x] `make test-smoke-linux`
- [x] `make test-smoke-vexpress`
- [x] `scripts/check-patch.sh --staged`
- [x] `scripts/check-dco.sh --last 1`

Closes #115
