### PR TITLE
build: add PlatformIO support for ESP32-C3 and ESP32-S3

### DIFF
--- a/.github/workflows/ci-platformio.yml
+++ b/.github/workflows/ci-platformio.yml
@@ -58,9 +58,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.platformio
-          key: pio-${{ hashFiles('platform/esp32c3/platformio.ini') }}
+          key: pio-${{ hashFiles('platform/esp32c3/platformio.ini', 'platform/esp32s3/platformio.ini') }}
           restore-keys: pio-
 
       - name: Build ESP32-C3 devkit via PlatformIO
         working-directory: platform/esp32c3
         run: pio run -e esp32c3_devkit
+
+      - name: Build ESP32-S3 qemu via PlatformIO
+        working-directory: platform/esp32s3
+        run: pio run -e esp32s3_qemu

--- a/.github/workflows/ci-platformio.yml
+++ b/.github/workflows/ci-platformio.yml
@@ -9,9 +9,12 @@ on:
       - 'include/**'
       - 'drivers/**'
       - 'platform/esp32c3/**'
+      - 'platform/esp32s3/**'
+      - 'platform/common/**'
       - 'scripts/**'
       - 'meson.build'
       - 'meson_options.txt'
+      - 'claw_config.h'
       - '.github/workflows/ci-platformio.yml'
   pull_request:
     paths:
@@ -20,9 +23,12 @@ on:
       - 'include/**'
       - 'drivers/**'
       - 'platform/esp32c3/**'
+      - 'platform/esp32s3/**'
+      - 'platform/common/**'
       - 'scripts/**'
       - 'meson.build'
       - 'meson_options.txt'
+      - 'claw_config.h'
       - '.github/workflows/ci-platformio.yml'
   workflow_dispatch:
 

--- a/.github/workflows/ci-platformio.yml
+++ b/.github/workflows/ci-platformio.yml
@@ -1,0 +1,60 @@
+name: CI PlatformIO Smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'claw/**'
+      - 'osal/**'
+      - 'include/**'
+      - 'drivers/**'
+      - 'platform/esp32c3/**'
+      - 'scripts/**'
+      - 'meson.build'
+      - 'meson_options.txt'
+      - '.github/workflows/ci-platformio.yml'
+  pull_request:
+    paths:
+      - 'claw/**'
+      - 'osal/**'
+      - 'include/**'
+      - 'drivers/**'
+      - 'platform/esp32c3/**'
+      - 'scripts/**'
+      - 'meson.build'
+      - 'meson_options.txt'
+      - '.github/workflows/ci-platformio.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-pio-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-platformio:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PlatformIO and build tools
+        run: pip install platformio meson ninja
+
+      - name: Cache PlatformIO packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.platformio
+          key: pio-${{ hashFiles('platform/esp32c3/platformio.ini') }}
+          restore-keys: pio-
+
+      - name: Build ESP32-C3 devkit via PlatformIO
+        working-directory: platform/esp32c3
+        run: pio run -e esp32c3_devkit

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ package-lock.json
 !.claude/skills/
 .humanize*
 slides
+
+# PlatformIO generated (per-env sdkconfig, stub sources)
+sdkconfig.*
+rt_claw_stub.c

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,14 @@ packages/
 sd.bin
 platform/*/cross.ini
 
+# Node.js (Codex CLI)
+node_modules/
+package.json
+package-lock.json
+
+# Codex
+.codex
+
 # Claude Code
 .claude/*
 !.claude/skills/

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ package-lock.json
 # Codex
 .codex
 
+# PlatformIO
+.pio/
+
 # Claude Code
 .claude/*
 !.claude/skills/

--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,5 @@ package-lock.json
 slides
 
 # PlatformIO generated (per-env sdkconfig, stub sources)
-sdkconfig.*
+sdkconfig.esp32*
 rt_claw_stub.c

--- a/docs/en/platformio.md
+++ b/docs/en/platformio.md
@@ -41,15 +41,26 @@ The pre-build script (`scripts/pio_pre_build.py`) automatically:
 ## Flash
 
 ```bash
+# ESP32-C3
 cd platform/esp32c3
 pio run -e esp32c3_devkit -t upload
 pio run -e esp32c3_xiaozhi_xmini -t upload
+
+# ESP32-S3
+cd platform/esp32s3
+pio run -e esp32s3_default -t upload
 ```
 
 ## Monitor
 
 ```bash
+# ESP32-C3
+cd platform/esp32c3
 pio run -e esp32c3_devkit -t monitor
+
+# ESP32-S3
+cd platform/esp32s3
+pio run -e esp32s3_default -t monitor
 ```
 
 ## Environment Variables

--- a/docs/en/platformio.md
+++ b/docs/en/platformio.md
@@ -30,13 +30,14 @@ pio run -e esp32s3_default         # real hardware (16MB + PSRAM)
 pio run -e esp32s3_qemu            # QEMU virtual board
 ```
 
-The pre-build script (`scripts/pio_pre_build.py`) automatically:
+The build uses two extra scripts:
 
-1. Detects the ESP-IDF bundled with PlatformIO
-2. Configures ESP-IDF (`idf.py set-target` + `reconfigure`)
-3. Generates Meson cross-compilation files
-4. Builds rt-claw libraries via Meson
-5. Lets CMake merge the objects into the final firmware
+1. **Pre-build** (`pio_pre_build.py`): checks tools (meson, ninja) and
+   sets CMake variables for the Meson bridge
+2. **Post-configure** (`pio_post_configure.py`): runs after ESP-IDF cmake
+   configure, invokes the Meson bridge helper which generates cross-files
+   from PlatformIO's `compile_commands.json`, validates compiler consistency,
+   detects stale Meson builds, and runs `meson compile`
 
 ## Flash
 

--- a/docs/en/platformio.md
+++ b/docs/en/platformio.md
@@ -1,0 +1,76 @@
+# PlatformIO Build Guide
+
+rt-claw supports PlatformIO as an alternative build system for ESP32-C3 and
+ESP32-S3 targets. PlatformIO manages the ESP-IDF toolchain automatically —
+no manual installation required.
+
+## Prerequisites
+
+- [PlatformIO Core (CLI)](https://docs.platformio.org/en/latest/core/installation.html)
+- [Meson](https://mesonbuild.com/) and [Ninja](https://ninja-build.org/)
+
+```bash
+pip install platformio meson ninja
+```
+
+## Build
+
+Run from the platform directory (where `platformio.ini` lives):
+
+```bash
+# ESP32-C3
+cd platform/esp32c3
+pio run -e esp32c3_devkit          # generic 4MB devkit
+pio run -e esp32c3_xiaozhi_xmini   # xiaozhi-xmini 16MB board
+pio run -e esp32c3_qemu            # QEMU virtual board
+
+# ESP32-S3
+cd platform/esp32s3
+pio run -e esp32s3_default         # real hardware (16MB + PSRAM)
+pio run -e esp32s3_qemu            # QEMU virtual board
+```
+
+The pre-build script (`scripts/pio_pre_build.py`) automatically:
+
+1. Detects the ESP-IDF bundled with PlatformIO
+2. Configures ESP-IDF (`idf.py set-target` + `reconfigure`)
+3. Generates Meson cross-compilation files
+4. Builds rt-claw libraries via Meson
+5. Lets CMake merge the objects into the final firmware
+
+## Flash
+
+```bash
+cd platform/esp32c3
+pio run -e esp32c3_devkit -t upload
+pio run -e esp32c3_xiaozhi_xmini -t upload
+```
+
+## Monitor
+
+```bash
+pio run -e esp32c3_devkit -t monitor
+```
+
+## Environment Variables
+
+API keys and credentials are configured via environment variables (same as
+the Makefile build):
+
+```bash
+export RTCLAW_AI_API_KEY='sk-...'
+export RTCLAW_AI_API_URL='https://...'
+export RTCLAW_AI_MODEL='claude-sonnet-4-6'
+```
+
+## Coexistence with Makefile
+
+PlatformIO coexists with the existing Makefile/Meson/CMake build. Both
+systems share the same source code and build output directories under
+`build/<chip>-<board>/`. The Makefile build is unaffected by PlatformIO
+files.
+
+## Platform Version
+
+PlatformIO is pinned to `espressif32@6.10.0` (ESP-IDF v5.4.0) to match
+the project's toolchain requirements.

--- a/docs/zh/platformio.md
+++ b/docs/zh/platformio.md
@@ -40,15 +40,26 @@ pio run -e esp32s3_qemu            # QEMU 虚拟板
 ## 烧录
 
 ```bash
+# ESP32-C3
 cd platform/esp32c3
 pio run -e esp32c3_devkit -t upload
 pio run -e esp32c3_xiaozhi_xmini -t upload
+
+# ESP32-S3
+cd platform/esp32s3
+pio run -e esp32s3_default -t upload
 ```
 
 ## 串口监控
 
 ```bash
+# ESP32-C3
+cd platform/esp32c3
 pio run -e esp32c3_devkit -t monitor
+
+# ESP32-S3
+cd platform/esp32s3
+pio run -e esp32s3_default -t monitor
 ```
 
 ## 环境变量

--- a/docs/zh/platformio.md
+++ b/docs/zh/platformio.md
@@ -29,13 +29,14 @@ pio run -e esp32s3_default         # 实体硬件（16MB + PSRAM）
 pio run -e esp32s3_qemu            # QEMU 虚拟板
 ```
 
-预构建脚本（`scripts/pio_pre_build.py`）自动完成以下步骤：
+构建过程使用两个额外脚本：
 
-1. 检测 PlatformIO 自带的 ESP-IDF
-2. 配置 ESP-IDF（`idf.py set-target` + `reconfigure`）
-3. 生成 Meson 交叉编译文件
-4. 通过 Meson 构建 rt-claw 库
-5. 由 CMake 将目标文件合并到最终固件中
+1. **预构建**（`pio_pre_build.py`）：检查工具（meson、ninja）并设置
+   CMake 变量
+2. **后配置**（`pio_post_configure.py`）：在 ESP-IDF cmake 配置完成后
+   运行，调用 Meson 桥接助手从 PlatformIO 的 `compile_commands.json`
+   生成交叉编译文件，验证编译器一致性，检测过期 Meson 构建，并运行
+   `meson compile`
 
 ## 烧录
 

--- a/docs/zh/platformio.md
+++ b/docs/zh/platformio.md
@@ -1,0 +1,73 @@
+# PlatformIO 构建指南
+
+rt-claw 支持 PlatformIO 作为 ESP32-C3 和 ESP32-S3 目标的替代构建系统。
+PlatformIO 自动管理 ESP-IDF 工具链，无需手动安装。
+
+## 前置条件
+
+- [PlatformIO Core (CLI)](https://docs.platformio.org/en/latest/core/installation.html)
+- [Meson](https://mesonbuild.com/) 和 [Ninja](https://ninja-build.org/)
+
+```bash
+pip install platformio meson ninja
+```
+
+## 构建
+
+从 platform 目录（`platformio.ini` 所在位置）运行：
+
+```bash
+# ESP32-C3
+cd platform/esp32c3
+pio run -e esp32c3_devkit          # 通用 4MB 开发板
+pio run -e esp32c3_xiaozhi_xmini   # xiaozhi-xmini 16MB 板
+pio run -e esp32c3_qemu            # QEMU 虚拟板
+
+# ESP32-S3
+cd platform/esp32s3
+pio run -e esp32s3_default         # 实体硬件（16MB + PSRAM）
+pio run -e esp32s3_qemu            # QEMU 虚拟板
+```
+
+预构建脚本（`scripts/pio_pre_build.py`）自动完成以下步骤：
+
+1. 检测 PlatformIO 自带的 ESP-IDF
+2. 配置 ESP-IDF（`idf.py set-target` + `reconfigure`）
+3. 生成 Meson 交叉编译文件
+4. 通过 Meson 构建 rt-claw 库
+5. 由 CMake 将目标文件合并到最终固件中
+
+## 烧录
+
+```bash
+cd platform/esp32c3
+pio run -e esp32c3_devkit -t upload
+pio run -e esp32c3_xiaozhi_xmini -t upload
+```
+
+## 串口监控
+
+```bash
+pio run -e esp32c3_devkit -t monitor
+```
+
+## 环境变量
+
+API 密钥和凭证通过环境变量配置（与 Makefile 构建相同）：
+
+```bash
+export RTCLAW_AI_API_KEY='sk-...'
+export RTCLAW_AI_API_URL='https://...'
+export RTCLAW_AI_MODEL='claude-sonnet-4-6'
+```
+
+## 与 Makefile 共存
+
+PlatformIO 与现有的 Makefile/Meson/CMake 构建共存。两套系统共享相同的
+源代码和 `build/<chip>-<board>/` 下的构建输出目录。PlatformIO 文件不会
+影响 Makefile 构建。
+
+## 平台版本
+
+PlatformIO 锁定为 `espressif32@6.10.0`（ESP-IDF v5.4.0），以匹配
+项目的工具链要求。

--- a/platform/esp32c3/CMakeLists.txt
+++ b/platform/esp32c3/CMakeLists.txt
@@ -7,8 +7,11 @@ endif()
 set(SDKCONFIG_DEFAULTS
     "${CMAKE_CURRENT_LIST_DIR}/boards/${RTCLAW_BOARD}/sdkconfig.defaults")
 
-# Put sdkconfig in the build directory (supports parallel multi-board builds)
-set(SDKCONFIG "${CMAKE_BINARY_DIR}/sdkconfig")
+# Put sdkconfig in the build directory (supports parallel multi-board builds).
+# PlatformIO passes -DSDKCONFIG=... so only set the default when not provided.
+if(NOT DEFINED SDKCONFIG)
+    set(SDKCONFIG "${CMAKE_BINARY_DIR}/sdkconfig")
+endif()
 
 set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/components")
 

--- a/platform/esp32c3/boards_pio/rtclaw_xiaozhi_xmini.json
+++ b/platform/esp32c3/boards_pio/rtclaw_xiaozhi_xmini.json
@@ -1,0 +1,34 @@
+{
+    "build": {
+        "arduino": {
+            "ldscript": "esp32c3_out.ld"
+        },
+        "core": "esp32",
+        "extra_flags": "",
+        "f_cpu": "160000000L",
+        "f_flash": "80000000L",
+        "flash_mode": "dio",
+        "mcu": "esp32c3",
+        "variant": "esp32c3"
+    },
+    "connectivity": [
+        "wifi",
+        "bluetooth"
+    ],
+    "debug": {
+        "openocd_target": "esp32c3"
+    },
+    "frameworks": [
+        "espidf"
+    ],
+    "name": "RT-Claw XiaoZhi xMini (ESP32-C3, 16MB)",
+    "upload": {
+        "flash_size": "16MB",
+        "maximum_ram_size": 327680,
+        "maximum_size": 16777216,
+        "require_upload_port": true,
+        "speed": 460800
+    },
+    "url": "https://github.com/zevorn/rt-claw",
+    "vendor": "RT-Claw"
+}

--- a/platform/esp32c3/components/rt_claw/CMakeLists.txt
+++ b/platform/esp32c3/components/rt_claw/CMakeLists.txt
@@ -59,72 +59,9 @@ if(_GIT_RC EQUAL 0)
         RT_CLAW_VERSION=\"${_GIT_VERSION}\")
 endif()
 
-if(RTCLAW_PLATFORMIO)
-    # PlatformIO path: run gen-cross.py + meson compile as a custom target,
-    # then link the Meson static archives into the component interface.
-    # This keeps Meson objects in the firmware link only (not the bootloader).
-
-    set(_gen_cross "${RT_CLAW_ROOT}/scripts/gen-esp32c3-cross.py")
-    set(_board_build_dir "${MESON_BUILD_DIR}/..")
-
-    set(_meson_stamp "${MESON_BUILD_DIR}/.pio_meson_done")
-    set(_meson_script "${CMAKE_CURRENT_BINARY_DIR}/run_meson.cmake")
-    file(WRITE "${_meson_script}" "
-        execute_process(
-            COMMAND ${Python3_EXECUTABLE} \"${_gen_cross}\"
-                --idf-build-dir \"${CMAKE_BINARY_DIR}\"
-                --board-build-dir \"${_board_build_dir}\"
-                \"${RTCLAW_BOARD}\"
-            WORKING_DIRECTORY \"${RT_CLAW_ROOT}\"
-            RESULT_VARIABLE _rc
-        )
-        if(NOT _rc EQUAL 0)
-            message(FATAL_ERROR \"gen-esp32c3-cross.py failed\")
-        endif()
-        set(_cross_ini \"${_board_build_dir}/cross.ini\")
-        set(_build_ninja \"${MESON_BUILD_DIR}/build.ninja\")
-        if(NOT EXISTS \${_build_ninja})
-            execute_process(
-                COMMAND meson setup \"${MESON_BUILD_DIR}\"
-                    --cross-file=\${_cross_ini}
-                WORKING_DIRECTORY \"${RT_CLAW_ROOT}\"
-                RESULT_VARIABLE _rc
-            )
-            if(NOT _rc EQUAL 0)
-                message(FATAL_ERROR \"meson setup failed\")
-            endif()
-        endif()
-        execute_process(
-            COMMAND meson compile -C \"${MESON_BUILD_DIR}\"
-            WORKING_DIRECTORY \"${RT_CLAW_ROOT}\"
-            RESULT_VARIABLE _rc
-        )
-        if(NOT _rc EQUAL 0)
-            message(FATAL_ERROR \"meson compile failed\")
-        endif()
-        file(WRITE \"${_meson_stamp}\" \"done\")
-    ")
-
-    add_custom_command(
-        OUTPUT "${_meson_stamp}"
-        COMMAND ${CMAKE_COMMAND} -DPython3_EXECUTABLE=${Python3_EXECUTABLE}
-            -P "${_meson_script}"
-        COMMENT "Building rt-claw Meson libraries for PlatformIO"
-        VERBATIM
-    )
-    add_custom_target(rtclaw_meson_build DEPENDS "${_meson_stamp}")
-    add_dependencies(${COMPONENT_LIB} rtclaw_meson_build)
-
-    set(_rtclaw_a "${MESON_BUILD_DIR}/claw/librtclaw.a")
-    set(_osal_a   "${MESON_BUILD_DIR}/osal/libosal.a")
-    set(_cjson_a  "${MESON_BUILD_DIR}/vendor/lib/cjson/libcjson.a")
-
-    target_link_libraries(${COMPONENT_LIB} INTERFACE
-        -Wl,--whole-archive
-        "${_rtclaw_a}" "${_osal_a}" "${_cjson_a}"
-        -Wl,--no-whole-archive
-    )
-else()
+if(NOT RTCLAW_PLATFORMIO)
+    # Makefile/idf.py path: merge Meson pre-built objects via POST_BUILD.
+    # PlatformIO path handles Meson via pio_post_configure.py + LINKFLAGS.
     # Makefile/idf.py path: merge Meson pre-built objects via POST_BUILD.
     set(_merge_script "${CMAKE_CURRENT_BINARY_DIR}/merge_meson_objs.cmake")
     file(WRITE "${_merge_script}" "

--- a/platform/esp32c3/components/rt_claw/CMakeLists.txt
+++ b/platform/esp32c3/components/rt_claw/CMakeLists.txt
@@ -5,12 +5,10 @@ else()
     set(MESON_BUILD_DIR "${RT_CLAW_ROOT}/build/esp32c3-${RTCLAW_BOARD}/meson")
 endif()
 
-# Headers exported to dependent components (e.g. main)
 set(CLAW_INC_DIRS
     "${RT_CLAW_ROOT}/include"
 )
 
-# ESP-IDF component dependencies (needed for symbol resolution at link time)
 set(CLAW_REQUIRES
     freertos
     esp_netif
@@ -26,22 +24,14 @@ set(CLAW_REQUIRES
     esp_hw_support
 )
 
-# Unconditional: ESP-IDF processes component REQUIRES before sdkconfig
-# is available, so CONFIG_* conditionals cannot gate REQUIRES here.
-# These components always exist; unused ones add only include paths.
 list(APPEND CLAW_REQUIRES esp_eth esp_wifi esp_lcd esp_driver_i2c
      esp_driver_i2s app_update esp_http_server)
 
-# Stub source so the component produces a real static library
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/rt_claw_stub.c" "/* auto-generated */\n")
 set(CLAW_SRCS "${CMAKE_CURRENT_BINARY_DIR}/rt_claw_stub.c")
 
-# es8311 audio driver — compiled by CMake (not Meson) because it
-# depends on esp_codec_dev managed component headers.
 list(APPEND CLAW_SRCS "${RT_CLAW_ROOT}/drivers/audio/espressif/es8311_audio.c")
 
-# Platform OTA implementation — must live in rt_claw (not main) so the
-# linker resolves symbols referenced by Meson-compiled ota_service.o.
 if(CONFIG_RTCLAW_OTA_ENABLE)
     list(APPEND CLAW_SRCS "${RT_CLAW_ROOT}/platform/common/espressif/esp_ota.c")
 endif()
@@ -57,7 +47,6 @@ idf_component_register(
 target_compile_definitions(${COMPONENT_LIB} PUBLIC CLAW_PLATFORM_ESP_IDF)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Werror)
 
-# Version from git describe
 execute_process(
     COMMAND git describe --tags --dirty=-dirty
     WORKING_DIRECTORY ${RT_CLAW_ROOT}
@@ -70,13 +59,75 @@ if(_GIT_RC EQUAL 0)
         RT_CLAW_VERSION=\"${_GIT_VERSION}\")
 endif()
 
-# Merge Meson pre-built objects into the component library so they
-# participate in ESP-IDF's normal link group (resolves cross-references).
-#
-# The glob runs at BUILD time (not configure time) via a helper script,
-# because Meson objects may not exist yet when CMake configures.
-set(_merge_script "${CMAKE_CURRENT_BINARY_DIR}/merge_meson_objs.cmake")
-file(WRITE "${_merge_script}" "
+if(RTCLAW_PLATFORMIO)
+    # PlatformIO path: run gen-cross.py + meson compile as a custom target,
+    # then link the Meson static archives into the component interface.
+    # This keeps Meson objects in the firmware link only (not the bootloader).
+
+    set(_gen_cross "${RT_CLAW_ROOT}/scripts/gen-esp32c3-cross.py")
+    set(_board_build_dir "${MESON_BUILD_DIR}/..")
+
+    set(_meson_stamp "${MESON_BUILD_DIR}/.pio_meson_done")
+    set(_meson_script "${CMAKE_CURRENT_BINARY_DIR}/run_meson.cmake")
+    file(WRITE "${_meson_script}" "
+        execute_process(
+            COMMAND ${Python3_EXECUTABLE} \"${_gen_cross}\"
+                --idf-build-dir \"${CMAKE_BINARY_DIR}\"
+                --board-build-dir \"${_board_build_dir}\"
+                \"${RTCLAW_BOARD}\"
+            WORKING_DIRECTORY \"${RT_CLAW_ROOT}\"
+            RESULT_VARIABLE _rc
+        )
+        if(NOT _rc EQUAL 0)
+            message(FATAL_ERROR \"gen-esp32c3-cross.py failed\")
+        endif()
+        set(_cross_ini \"${_board_build_dir}/cross.ini\")
+        set(_build_ninja \"${MESON_BUILD_DIR}/build.ninja\")
+        if(NOT EXISTS \${_build_ninja})
+            execute_process(
+                COMMAND meson setup \"${MESON_BUILD_DIR}\"
+                    --cross-file=\${_cross_ini}
+                WORKING_DIRECTORY \"${RT_CLAW_ROOT}\"
+                RESULT_VARIABLE _rc
+            )
+            if(NOT _rc EQUAL 0)
+                message(FATAL_ERROR \"meson setup failed\")
+            endif()
+        endif()
+        execute_process(
+            COMMAND meson compile -C \"${MESON_BUILD_DIR}\"
+            WORKING_DIRECTORY \"${RT_CLAW_ROOT}\"
+            RESULT_VARIABLE _rc
+        )
+        if(NOT _rc EQUAL 0)
+            message(FATAL_ERROR \"meson compile failed\")
+        endif()
+        file(WRITE \"${_meson_stamp}\" \"done\")
+    ")
+
+    add_custom_command(
+        OUTPUT "${_meson_stamp}"
+        COMMAND ${CMAKE_COMMAND} -DPython3_EXECUTABLE=${Python3_EXECUTABLE}
+            -P "${_meson_script}"
+        COMMENT "Building rt-claw Meson libraries for PlatformIO"
+        VERBATIM
+    )
+    add_custom_target(rtclaw_meson_build DEPENDS "${_meson_stamp}")
+    add_dependencies(${COMPONENT_LIB} rtclaw_meson_build)
+
+    set(_rtclaw_a "${MESON_BUILD_DIR}/claw/librtclaw.a")
+    set(_osal_a   "${MESON_BUILD_DIR}/osal/libosal.a")
+    set(_cjson_a  "${MESON_BUILD_DIR}/vendor/lib/cjson/libcjson.a")
+
+    target_link_libraries(${COMPONENT_LIB} INTERFACE
+        -Wl,--whole-archive
+        "${_rtclaw_a}" "${_osal_a}" "${_cjson_a}"
+        -Wl,--no-whole-archive
+    )
+else()
+    # Makefile/idf.py path: merge Meson pre-built objects via POST_BUILD.
+    set(_merge_script "${CMAKE_CURRENT_BINARY_DIR}/merge_meson_objs.cmake")
+    file(WRITE "${_merge_script}" "
 file(GLOB _objs
     \"${MESON_BUILD_DIR}/claw/librtclaw.a.p/*.o\"
     \"${MESON_BUILD_DIR}/osal/libosal.a.p/*.o\"
@@ -92,11 +143,12 @@ else()
 endif()
 ")
 
-add_custom_command(TARGET ${COMPONENT_LIB} POST_BUILD
-    COMMAND ${CMAKE_COMMAND}
-        -DAR=${CMAKE_AR}
-        -DRANLIB=${CMAKE_RANLIB}
-        -DLIB=$<TARGET_FILE:${COMPONENT_LIB}>
-        -P "${_merge_script}"
-    COMMENT "Merging Meson pre-built objects into ${COMPONENT_LIB}"
-)
+    add_custom_command(TARGET ${COMPONENT_LIB} POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+            -DAR=${CMAKE_AR}
+            -DRANLIB=${CMAKE_RANLIB}
+            -DLIB=$<TARGET_FILE:${COMPONENT_LIB}>
+            -P "${_merge_script}"
+        COMMENT "Merging Meson pre-built objects into ${COMPONENT_LIB}"
+    )
+endif()

--- a/platform/esp32c3/components/rt_claw/CMakeLists.txt
+++ b/platform/esp32c3/components/rt_claw/CMakeLists.txt
@@ -1,5 +1,9 @@
 set(RT_CLAW_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../..")
-set(MESON_BUILD_DIR "${RT_CLAW_ROOT}/build/esp32c3-${RTCLAW_BOARD}/meson")
+if(DEFINED RTCLAW_MESON_BUILD_DIR)
+    set(MESON_BUILD_DIR "${RTCLAW_MESON_BUILD_DIR}")
+else()
+    set(MESON_BUILD_DIR "${RT_CLAW_ROOT}/build/esp32c3-${RTCLAW_BOARD}/meson")
+endif()
 
 # Headers exported to dependent components (e.g. main)
 set(CLAW_INC_DIRS

--- a/platform/esp32c3/pio_boards/rtclaw_xiaozhi_xmini.json
+++ b/platform/esp32c3/pio_boards/rtclaw_xiaozhi_xmini.json
@@ -9,6 +9,7 @@
         "f_flash": "80000000L",
         "flash_mode": "dio",
         "mcu": "esp32c3",
+        "partitions": "boards/xiaozhi-xmini/partitions.csv",
         "variant": "esp32c3"
     },
     "connectivity": [

--- a/platform/esp32c3/platformio.ini
+++ b/platform/esp32c3/platformio.ini
@@ -5,7 +5,7 @@
 
 [platformio]
 src_dir = main
-boards_dir = boards_pio
+boards_dir = pio_boards
 
 [env]
 platform = espressif32@6.10.0
@@ -13,13 +13,13 @@ framework = espidf
 extra_scripts = pre:../../scripts/pio_pre_build.py
 
 [env:esp32c3_qemu]
-board = esp32c3-devkitm-1
+board = esp32-c3-devkitm-1
 custom_rtclaw_board = qemu
 board_build.cmake_extra_args =
     -DRTCLAW_BOARD=qemu
 
 [env:esp32c3_devkit]
-board = esp32c3-devkitm-1
+board = esp32-c3-devkitm-1
 custom_rtclaw_board = devkit
 board_build.cmake_extra_args =
     -DRTCLAW_BOARD=devkit
@@ -27,5 +27,6 @@ board_build.cmake_extra_args =
 [env:esp32c3_xiaozhi_xmini]
 board = rtclaw_xiaozhi_xmini
 custom_rtclaw_board = xiaozhi-xmini
+board_build.partitions = boards/xiaozhi-xmini/partitions.csv
 board_build.cmake_extra_args =
     -DRTCLAW_BOARD=xiaozhi-xmini

--- a/platform/esp32c3/platformio.ini
+++ b/platform/esp32c3/platformio.ini
@@ -1,0 +1,31 @@
+; SPDX-License-Identifier: MIT
+;
+; PlatformIO project for rt-claw ESP32-C3 targets.
+; Run from this directory: cd platform/esp32c3 && pio run -e <env>
+
+[platformio]
+src_dir = main
+boards_dir = boards_pio
+
+[env]
+platform = espressif32@6.10.0
+framework = espidf
+extra_scripts = pre:../../scripts/pio_pre_build.py
+
+[env:esp32c3_qemu]
+board = esp32c3-devkitm-1
+custom_rtclaw_board = qemu
+board_build.cmake_extra_args =
+    -DRTCLAW_BOARD=qemu
+
+[env:esp32c3_devkit]
+board = esp32c3-devkitm-1
+custom_rtclaw_board = devkit
+board_build.cmake_extra_args =
+    -DRTCLAW_BOARD=devkit
+
+[env:esp32c3_xiaozhi_xmini]
+board = rtclaw_xiaozhi_xmini
+custom_rtclaw_board = xiaozhi-xmini
+board_build.cmake_extra_args =
+    -DRTCLAW_BOARD=xiaozhi-xmini

--- a/platform/esp32c3/platformio.ini
+++ b/platform/esp32c3/platformio.ini
@@ -10,7 +10,9 @@ boards_dir = pio_boards
 [env]
 platform = espressif32@6.10.0
 framework = espidf
-extra_scripts = pre:../../scripts/pio_pre_build.py
+extra_scripts =
+    pre:../../scripts/pio_pre_build.py
+    post:../../scripts/pio_post_configure.py
 
 [env:esp32c3_qemu]
 board = esp32-c3-devkitm-1

--- a/platform/esp32c3/platformio.ini
+++ b/platform/esp32c3/platformio.ini
@@ -15,12 +15,14 @@ extra_scripts = pre:../../scripts/pio_pre_build.py
 [env:esp32c3_qemu]
 board = esp32-c3-devkitm-1
 custom_rtclaw_board = qemu
+board_build.partitions = boards/qemu/partitions.csv
 board_build.cmake_extra_args =
     -DRTCLAW_BOARD=qemu
 
 [env:esp32c3_devkit]
 board = esp32-c3-devkitm-1
 custom_rtclaw_board = devkit
+board_build.partitions = boards/devkit/partitions.csv
 board_build.cmake_extra_args =
     -DRTCLAW_BOARD=devkit
 

--- a/platform/esp32s3/CMakeLists.txt
+++ b/platform/esp32s3/CMakeLists.txt
@@ -7,8 +7,11 @@ endif()
 set(SDKCONFIG_DEFAULTS
     "${CMAKE_CURRENT_LIST_DIR}/boards/${RTCLAW_BOARD}/sdkconfig.defaults")
 
-# Put sdkconfig in the build directory (supports parallel multi-board builds)
-set(SDKCONFIG "${CMAKE_BINARY_DIR}/sdkconfig")
+# Put sdkconfig in the build directory (supports parallel multi-board builds).
+# PlatformIO passes -DSDKCONFIG=... so only set the default when not provided.
+if(NOT DEFINED SDKCONFIG)
+    set(SDKCONFIG "${CMAKE_BINARY_DIR}/sdkconfig")
+endif()
 
 set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/components")
 

--- a/platform/esp32s3/components/rt_claw/CMakeLists.txt
+++ b/platform/esp32s3/components/rt_claw/CMakeLists.txt
@@ -1,5 +1,9 @@
 set(RT_CLAW_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../..")
-set(MESON_BUILD_DIR "${RT_CLAW_ROOT}/build/esp32s3-${RTCLAW_BOARD}/meson")
+if(DEFINED RTCLAW_MESON_BUILD_DIR)
+    set(MESON_BUILD_DIR "${RTCLAW_MESON_BUILD_DIR}")
+else()
+    set(MESON_BUILD_DIR "${RT_CLAW_ROOT}/build/esp32s3-${RTCLAW_BOARD}/meson")
+endif()
 
 # Headers exported to dependent components (e.g. main)
 set(CLAW_INC_DIRS

--- a/platform/esp32s3/components/rt_claw/CMakeLists.txt
+++ b/platform/esp32s3/components/rt_claw/CMakeLists.txt
@@ -5,12 +5,10 @@ else()
     set(MESON_BUILD_DIR "${RT_CLAW_ROOT}/build/esp32s3-${RTCLAW_BOARD}/meson")
 endif()
 
-# Headers exported to dependent components (e.g. main)
 set(CLAW_INC_DIRS
     "${RT_CLAW_ROOT}/include"
 )
 
-# ESP-IDF component dependencies (needed for symbol resolution at link time)
 set(CLAW_REQUIRES
     freertos
     esp_netif
@@ -26,23 +24,16 @@ set(CLAW_REQUIRES
     esp_hw_support
 )
 
-# Unconditional: ESP-IDF processes component REQUIRES before sdkconfig
-# is available, so CONFIG_* conditionals cannot gate REQUIRES here.
-# These components always exist; unused ones add only include paths.
 list(APPEND CLAW_REQUIRES esp_eth esp_wifi esp_lcd app_update esp_http_server)
 
-# Stub source so the component produces a real static library
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/rt_claw_stub.c" "/* auto-generated */\n")
 set(CLAW_SRCS "${CMAKE_CURRENT_BINARY_DIR}/rt_claw_stub.c")
 
-# USB HID mouse — requires esp_tinyusb managed component
 if(CONFIG_RTCLAW_USB_HID_MOUSE)
     list(APPEND CLAW_SRCS
         "${RT_CLAW_ROOT}/drivers/input/espressif/usb_hid_mouse.c")
 endif()
 
-# Platform OTA implementation — must live in rt_claw (not main) so the
-# linker resolves symbols referenced by Meson-compiled ota_service.o.
 if(CONFIG_RTCLAW_OTA_ENABLE)
     list(APPEND CLAW_SRCS "${RT_CLAW_ROOT}/platform/common/espressif/esp_ota.c")
 endif()
@@ -70,13 +61,70 @@ if(_GIT_RC EQUAL 0)
         RT_CLAW_VERSION=\"${_GIT_VERSION}\")
 endif()
 
-# Merge Meson pre-built objects into the component library so they
-# participate in ESP-IDF's normal link group (resolves cross-references).
-#
-# The glob runs at BUILD time (not configure time) via a helper script,
-# because Meson objects may not exist yet when CMake configures.
-set(_merge_script "${CMAKE_CURRENT_BINARY_DIR}/merge_meson_objs.cmake")
-file(WRITE "${_merge_script}" "
+if(RTCLAW_PLATFORMIO)
+    set(_gen_cross "${RT_CLAW_ROOT}/scripts/gen-esp32s3-cross.py")
+    set(_board_build_dir "${MESON_BUILD_DIR}/..")
+
+    set(_meson_stamp "${MESON_BUILD_DIR}/.pio_meson_done")
+    set(_meson_script "${CMAKE_CURRENT_BINARY_DIR}/run_meson.cmake")
+    file(WRITE "${_meson_script}" "
+        execute_process(
+            COMMAND ${Python3_EXECUTABLE} \"${_gen_cross}\"
+                --idf-build-dir \"${CMAKE_BINARY_DIR}\"
+                --board-build-dir \"${_board_build_dir}\"
+                \"${RTCLAW_BOARD}\"
+            WORKING_DIRECTORY \"${RT_CLAW_ROOT}\"
+            RESULT_VARIABLE _rc
+        )
+        if(NOT _rc EQUAL 0)
+            message(FATAL_ERROR \"gen-esp32s3-cross.py failed\")
+        endif()
+        set(_cross_ini \"${_board_build_dir}/cross.ini\")
+        set(_build_ninja \"${MESON_BUILD_DIR}/build.ninja\")
+        if(NOT EXISTS \${_build_ninja})
+            execute_process(
+                COMMAND meson setup \"${MESON_BUILD_DIR}\"
+                    --cross-file=\${_cross_ini}
+                WORKING_DIRECTORY \"${RT_CLAW_ROOT}\"
+                RESULT_VARIABLE _rc
+            )
+            if(NOT _rc EQUAL 0)
+                message(FATAL_ERROR \"meson setup failed\")
+            endif()
+        endif()
+        execute_process(
+            COMMAND meson compile -C \"${MESON_BUILD_DIR}\"
+            WORKING_DIRECTORY \"${RT_CLAW_ROOT}\"
+            RESULT_VARIABLE _rc
+        )
+        if(NOT _rc EQUAL 0)
+            message(FATAL_ERROR \"meson compile failed\")
+        endif()
+        file(WRITE \"${_meson_stamp}\" \"done\")
+    ")
+
+    add_custom_command(
+        OUTPUT "${_meson_stamp}"
+        COMMAND ${CMAKE_COMMAND} -DPython3_EXECUTABLE=${Python3_EXECUTABLE}
+            -P "${_meson_script}"
+        COMMENT "Building rt-claw Meson libraries for PlatformIO"
+        VERBATIM
+    )
+    add_custom_target(rtclaw_meson_build DEPENDS "${_meson_stamp}")
+    add_dependencies(${COMPONENT_LIB} rtclaw_meson_build)
+
+    set(_rtclaw_a "${MESON_BUILD_DIR}/claw/librtclaw.a")
+    set(_osal_a   "${MESON_BUILD_DIR}/osal/libosal.a")
+    set(_cjson_a  "${MESON_BUILD_DIR}/vendor/lib/cjson/libcjson.a")
+
+    target_link_libraries(${COMPONENT_LIB} INTERFACE
+        -Wl,--whole-archive
+        "${_rtclaw_a}" "${_osal_a}" "${_cjson_a}"
+        -Wl,--no-whole-archive
+    )
+else()
+    set(_merge_script "${CMAKE_CURRENT_BINARY_DIR}/merge_meson_objs.cmake")
+    file(WRITE "${_merge_script}" "
 file(GLOB _objs
     \"${MESON_BUILD_DIR}/claw/librtclaw.a.p/*.o\"
     \"${MESON_BUILD_DIR}/osal/libosal.a.p/*.o\"
@@ -92,11 +140,12 @@ else()
 endif()
 ")
 
-add_custom_command(TARGET ${COMPONENT_LIB} POST_BUILD
-    COMMAND ${CMAKE_COMMAND}
-        -DAR=${CMAKE_AR}
-        -DRANLIB=${CMAKE_RANLIB}
-        -DLIB=$<TARGET_FILE:${COMPONENT_LIB}>
-        -P "${_merge_script}"
-    COMMENT "Merging Meson pre-built objects into ${COMPONENT_LIB}"
-)
+    add_custom_command(TARGET ${COMPONENT_LIB} POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+            -DAR=${CMAKE_AR}
+            -DRANLIB=${CMAKE_RANLIB}
+            -DLIB=$<TARGET_FILE:${COMPONENT_LIB}>
+            -P "${_merge_script}"
+        COMMENT "Merging Meson pre-built objects into ${COMPONENT_LIB}"
+    )
+endif()

--- a/platform/esp32s3/components/rt_claw/CMakeLists.txt
+++ b/platform/esp32s3/components/rt_claw/CMakeLists.txt
@@ -61,68 +61,7 @@ if(_GIT_RC EQUAL 0)
         RT_CLAW_VERSION=\"${_GIT_VERSION}\")
 endif()
 
-if(RTCLAW_PLATFORMIO)
-    set(_gen_cross "${RT_CLAW_ROOT}/scripts/gen-esp32s3-cross.py")
-    set(_board_build_dir "${MESON_BUILD_DIR}/..")
-
-    set(_meson_stamp "${MESON_BUILD_DIR}/.pio_meson_done")
-    set(_meson_script "${CMAKE_CURRENT_BINARY_DIR}/run_meson.cmake")
-    file(WRITE "${_meson_script}" "
-        execute_process(
-            COMMAND ${Python3_EXECUTABLE} \"${_gen_cross}\"
-                --idf-build-dir \"${CMAKE_BINARY_DIR}\"
-                --board-build-dir \"${_board_build_dir}\"
-                \"${RTCLAW_BOARD}\"
-            WORKING_DIRECTORY \"${RT_CLAW_ROOT}\"
-            RESULT_VARIABLE _rc
-        )
-        if(NOT _rc EQUAL 0)
-            message(FATAL_ERROR \"gen-esp32s3-cross.py failed\")
-        endif()
-        set(_cross_ini \"${_board_build_dir}/cross.ini\")
-        set(_build_ninja \"${MESON_BUILD_DIR}/build.ninja\")
-        if(NOT EXISTS \${_build_ninja})
-            execute_process(
-                COMMAND meson setup \"${MESON_BUILD_DIR}\"
-                    --cross-file=\${_cross_ini}
-                WORKING_DIRECTORY \"${RT_CLAW_ROOT}\"
-                RESULT_VARIABLE _rc
-            )
-            if(NOT _rc EQUAL 0)
-                message(FATAL_ERROR \"meson setup failed\")
-            endif()
-        endif()
-        execute_process(
-            COMMAND meson compile -C \"${MESON_BUILD_DIR}\"
-            WORKING_DIRECTORY \"${RT_CLAW_ROOT}\"
-            RESULT_VARIABLE _rc
-        )
-        if(NOT _rc EQUAL 0)
-            message(FATAL_ERROR \"meson compile failed\")
-        endif()
-        file(WRITE \"${_meson_stamp}\" \"done\")
-    ")
-
-    add_custom_command(
-        OUTPUT "${_meson_stamp}"
-        COMMAND ${CMAKE_COMMAND} -DPython3_EXECUTABLE=${Python3_EXECUTABLE}
-            -P "${_meson_script}"
-        COMMENT "Building rt-claw Meson libraries for PlatformIO"
-        VERBATIM
-    )
-    add_custom_target(rtclaw_meson_build DEPENDS "${_meson_stamp}")
-    add_dependencies(${COMPONENT_LIB} rtclaw_meson_build)
-
-    set(_rtclaw_a "${MESON_BUILD_DIR}/claw/librtclaw.a")
-    set(_osal_a   "${MESON_BUILD_DIR}/osal/libosal.a")
-    set(_cjson_a  "${MESON_BUILD_DIR}/vendor/lib/cjson/libcjson.a")
-
-    target_link_libraries(${COMPONENT_LIB} INTERFACE
-        -Wl,--whole-archive
-        "${_rtclaw_a}" "${_osal_a}" "${_cjson_a}"
-        -Wl,--no-whole-archive
-    )
-else()
+if(NOT RTCLAW_PLATFORMIO)
     set(_merge_script "${CMAKE_CURRENT_BINARY_DIR}/merge_meson_objs.cmake")
     file(WRITE "${_merge_script}" "
 file(GLOB _objs

--- a/platform/esp32s3/platformio.ini
+++ b/platform/esp32s3/platformio.ini
@@ -14,11 +14,14 @@ extra_scripts = pre:../../scripts/pio_pre_build.py
 [env:esp32s3_qemu]
 board = esp32-s3-devkitc-1
 custom_rtclaw_board = qemu
+board_build.partitions = boards/qemu/partitions.csv
 board_build.cmake_extra_args =
     -DRTCLAW_BOARD=qemu
 
 [env:esp32s3_default]
 board = esp32-s3-devkitc-1
 custom_rtclaw_board = default
+board_upload.flash_size = 16MB
+board_build.partitions = boards/default/partitions.csv
 board_build.cmake_extra_args =
     -DRTCLAW_BOARD=default

--- a/platform/esp32s3/platformio.ini
+++ b/platform/esp32s3/platformio.ini
@@ -9,7 +9,9 @@ src_dir = main
 [env]
 platform = espressif32@6.10.0
 framework = espidf
-extra_scripts = pre:../../scripts/pio_pre_build.py
+extra_scripts =
+    pre:../../scripts/pio_pre_build.py
+    post:../../scripts/pio_post_configure.py
 
 [env:esp32s3_qemu]
 board = esp32-s3-devkitc-1

--- a/platform/esp32s3/platformio.ini
+++ b/platform/esp32s3/platformio.ini
@@ -1,0 +1,24 @@
+; SPDX-License-Identifier: MIT
+;
+; PlatformIO project for rt-claw ESP32-S3 targets.
+; Run from this directory: cd platform/esp32s3 && pio run -e <env>
+
+[platformio]
+src_dir = main
+
+[env]
+platform = espressif32@6.10.0
+framework = espidf
+extra_scripts = pre:../../scripts/pio_pre_build.py
+
+[env:esp32s3_qemu]
+board = esp32-s3-devkitc-1
+custom_rtclaw_board = qemu
+board_build.cmake_extra_args =
+    -DRTCLAW_BOARD=qemu
+
+[env:esp32s3_default]
+board = esp32-s3-devkitc-1
+custom_rtclaw_board = default
+board_build.cmake_extra_args =
+    -DRTCLAW_BOARD=default

--- a/scripts/gen-esp32c3-cross.py
+++ b/scripts/gen-esp32c3-cross.py
@@ -96,6 +96,8 @@ def main():
     for p in all_includes:
         if any(d in p for d in project_src_dirs):
             continue
+        if not os.path.isabs(p):
+            p = os.path.normpath(os.path.join(idf_build_dir, p))
         idf_includes.append(p)
 
     """ Architecture and compiler flags """

--- a/scripts/gen-esp32c3-cross.py
+++ b/scripts/gen-esp32c3-cross.py
@@ -15,6 +15,7 @@
 #   python3 scripts/gen-esp32c3-cross.py devkit        # devkit board
 #   python3 scripts/gen-esp32c3-cross.py xiaozhi-xmini  # xiaozhi-xmini board
 
+import argparse
 import io
 import json
 import os
@@ -23,25 +24,45 @@ import sys
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-BOARD = sys.argv[1] if len(sys.argv) > 1 else 'qemu'
 
-BOARD_BUILD_DIR = os.path.join(PROJECT_ROOT, 'build', f'esp32c3-{BOARD}')
-IDF_BUILD_DIR = os.path.join(BOARD_BUILD_DIR, 'idf')
-CC_JSON = os.path.join(IDF_BUILD_DIR, 'compile_commands.json')
-CROSS_INI = os.path.join(BOARD_BUILD_DIR, 'cross.ini')
-SDKCONFIG_H = os.path.join(IDF_BUILD_DIR, 'config', 'sdkconfig.h')
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Generate Meson cross-file for ESP32-C3 from ESP-IDF '
+                    'build config.')
+    parser.add_argument('board', nargs='?', default='qemu',
+                        help='Board name (default: qemu)')
+    parser.add_argument('--idf-build-dir',
+                        help='Override IDF build directory path')
+    parser.add_argument('--board-build-dir',
+                        help='Override board build directory path')
+    parser.add_argument('--cross-file',
+                        help='Override output cross-file path')
+    return parser.parse_args()
 
 
 def main():
-    if not os.path.exists(CC_JSON):
-        print(f'Error: {CC_JSON} not found.', file=sys.stderr)
+    args = parse_args()
+    board = args.board
+
+    board_build_dir = (args.board_build_dir or
+                       os.path.join(PROJECT_ROOT, 'build',
+                                    f'esp32c3-{board}'))
+    idf_build_dir = (args.idf_build_dir or
+                     os.path.join(board_build_dir, 'idf'))
+    cc_json = os.path.join(idf_build_dir, 'compile_commands.json')
+    cross_ini = (args.cross_file or
+                 os.path.join(board_build_dir, 'cross.ini'))
+    sdkconfig_h = os.path.join(idf_build_dir, 'config', 'sdkconfig.h')
+
+    if not os.path.exists(cc_json):
+        print(f'Error: {cc_json} not found.', file=sys.stderr)
         print('Run first:', file=sys.stderr)
-        print(f'  cd platform/esp32c3 && idf.py -B {IDF_BUILD_DIR} '
-              f'-DRTCLAW_BOARD={BOARD} set-target esp32c3',
+        print(f'  cd platform/esp32c3 && idf.py -B {idf_build_dir} '
+              f'-DRTCLAW_BOARD={board} set-target esp32c3',
               file=sys.stderr)
         return 1
 
-    with open(CC_JSON) as f:
+    with open(cc_json) as f:
         cc = json.load(f)
 
     """ Find a source entry to extract ESP-IDF flags """
@@ -88,9 +109,9 @@ def main():
     ]
 
     """ Force-include sdkconfig.h so CONFIG_* macros are available """
-    if os.path.exists(SDKCONFIG_H):
+    if os.path.exists(sdkconfig_h):
         c_args.append(f'-include')
-        c_args.append(SDKCONFIG_H)
+        c_args.append(sdkconfig_h)
 
     """ ESP-IDF platform defines """
     c_args.extend([
@@ -109,12 +130,12 @@ def main():
         c_args.append(inc)
 
     """ Write cross.ini (only update file if content changed) """
-    os.makedirs(os.path.dirname(CROSS_INI), exist_ok=True)
+    os.makedirs(os.path.dirname(cross_ini), exist_ok=True)
     buf = io.StringIO()
     f = buf
 
     f.write('# Auto-generated Meson cross-file for ESP32-C3 (ESP-IDF)\n')
-    f.write(f'# Board: {BOARD}\n')
+    f.write(f'# Board: {board}\n')
     f.write('# Regenerate: python3 scripts/gen-esp32c3-cross.py\n')
     f.write('# DO NOT edit manually or commit to git.\n\n')
 
@@ -153,8 +174,8 @@ def main():
         'CONFIG_RTCLAW_OTA_ENABLE':       'ota',
     }
     enabled = set()
-    if os.path.exists(SDKCONFIG_H):
-        with open(SDKCONFIG_H) as sh:
+    if os.path.exists(sdkconfig_h):
+        with open(sdkconfig_h) as sh:
             for line in sh:
                 for kconf in kconfig_to_meson:
                     if f'#define {kconf} ' in line or \
@@ -166,18 +187,18 @@ def main():
 
     new_content = buf.getvalue()
     old_content = ''
-    if os.path.exists(CROSS_INI):
-        with open(CROSS_INI) as existing:
+    if os.path.exists(cross_ini):
+        with open(cross_ini) as existing:
             old_content = existing.read()
     if new_content != old_content:
-        with open(CROSS_INI, 'w') as out:
+        with open(cross_ini, 'w') as out:
             out.write(new_content)
 
-    print(f'Generated: {CROSS_INI}')
-    print(f'  Board:     {BOARD}')
+    print(f'Generated: {cross_ini}')
+    print(f'  Board:     {board}')
     print(f'  Compiler:  {compiler}')
     print(f'  Includes:  {len(idf_includes)} ESP-IDF paths')
-    print(f'  sdkconfig: {SDKCONFIG_H}')
+    print(f'  sdkconfig: {sdkconfig_h}')
     return 0
 
 

--- a/scripts/gen-esp32s3-cross.py
+++ b/scripts/gen-esp32s3-cross.py
@@ -14,6 +14,7 @@
 #   python3 scripts/gen-esp32s3-cross.py              # QEMU
 #   python3 scripts/gen-esp32s3-cross.py default       # real hardware
 
+import argparse
 import io
 import json
 import os
@@ -22,25 +23,45 @@ import sys
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-BOARD = sys.argv[1] if len(sys.argv) > 1 else 'qemu'
 
-BOARD_BUILD_DIR = os.path.join(PROJECT_ROOT, 'build', f'esp32s3-{BOARD}')
-IDF_BUILD_DIR = os.path.join(BOARD_BUILD_DIR, 'idf')
-CC_JSON = os.path.join(IDF_BUILD_DIR, 'compile_commands.json')
-CROSS_INI = os.path.join(BOARD_BUILD_DIR, 'cross.ini')
-SDKCONFIG_H = os.path.join(IDF_BUILD_DIR, 'config', 'sdkconfig.h')
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Generate Meson cross-file for ESP32-S3 from ESP-IDF '
+                    'build config.')
+    parser.add_argument('board', nargs='?', default='qemu',
+                        help='Board name (default: qemu)')
+    parser.add_argument('--idf-build-dir',
+                        help='Override IDF build directory path')
+    parser.add_argument('--board-build-dir',
+                        help='Override board build directory path')
+    parser.add_argument('--cross-file',
+                        help='Override output cross-file path')
+    return parser.parse_args()
 
 
 def main():
-    if not os.path.exists(CC_JSON):
-        print(f'Error: {CC_JSON} not found.', file=sys.stderr)
+    args = parse_args()
+    board = args.board
+
+    board_build_dir = (args.board_build_dir or
+                       os.path.join(PROJECT_ROOT, 'build',
+                                    f'esp32s3-{board}'))
+    idf_build_dir = (args.idf_build_dir or
+                     os.path.join(board_build_dir, 'idf'))
+    cc_json = os.path.join(idf_build_dir, 'compile_commands.json')
+    cross_ini = (args.cross_file or
+                 os.path.join(board_build_dir, 'cross.ini'))
+    sdkconfig_h = os.path.join(idf_build_dir, 'config', 'sdkconfig.h')
+
+    if not os.path.exists(cc_json):
+        print(f'Error: {cc_json} not found.', file=sys.stderr)
         print('Run first:', file=sys.stderr)
-        print(f'  cd platform/esp32s3 && idf.py -B {IDF_BUILD_DIR} '
-              f'-DRTCLAW_BOARD={BOARD} set-target esp32s3',
+        print(f'  cd platform/esp32s3 && idf.py -B {idf_build_dir} '
+              f'-DRTCLAW_BOARD={board} set-target esp32s3',
               file=sys.stderr)
         return 1
 
-    with open(CC_JSON) as f:
+    with open(cc_json) as f:
         cc = json.load(f)
 
     """ Find a source entry to extract ESP-IDF flags """
@@ -86,9 +107,9 @@ def main():
     ]
 
     """ Force-include sdkconfig.h so CONFIG_* macros are available """
-    if os.path.exists(SDKCONFIG_H):
+    if os.path.exists(sdkconfig_h):
         c_args.append(f'-include')
-        c_args.append(SDKCONFIG_H)
+        c_args.append(sdkconfig_h)
 
     """ ESP-IDF platform defines """
     c_args.extend([
@@ -107,12 +128,12 @@ def main():
         c_args.append(inc)
 
     """ Write cross.ini (only update file if content changed) """
-    os.makedirs(os.path.dirname(CROSS_INI), exist_ok=True)
+    os.makedirs(os.path.dirname(cross_ini), exist_ok=True)
     buf = io.StringIO()
     f = buf
 
     f.write('# Auto-generated Meson cross-file for ESP32-S3 (ESP-IDF)\n')
-    f.write(f'# Board: {BOARD}\n')
+    f.write(f'# Board: {board}\n')
     f.write('# Regenerate: python3 scripts/gen-esp32s3-cross.py\n')
     f.write('# DO NOT edit manually or commit to git.\n\n')
 
@@ -151,8 +172,8 @@ def main():
         'CONFIG_RTCLAW_OTA_ENABLE':       'ota',
     }
     enabled = set()
-    if os.path.exists(SDKCONFIG_H):
-        with open(SDKCONFIG_H) as sh:
+    if os.path.exists(sdkconfig_h):
+        with open(sdkconfig_h) as sh:
             for line in sh:
                 for kconf in kconfig_to_meson:
                     if f'#define {kconf} ' in line or \
@@ -164,18 +185,18 @@ def main():
 
     new_content = buf.getvalue()
     old_content = ''
-    if os.path.exists(CROSS_INI):
-        with open(CROSS_INI) as existing:
+    if os.path.exists(cross_ini):
+        with open(cross_ini) as existing:
             old_content = existing.read()
     if new_content != old_content:
-        with open(CROSS_INI, 'w') as out:
+        with open(cross_ini, 'w') as out:
             out.write(new_content)
 
-    print(f'Generated: {CROSS_INI}')
-    print(f'  Board:     {BOARD}')
+    print(f'Generated: {cross_ini}')
+    print(f'  Board:     {board}')
     print(f'  Compiler:  {compiler}')
     print(f'  Includes:  {len(idf_includes)} ESP-IDF paths')
-    print(f'  sdkconfig: {SDKCONFIG_H}')
+    print(f'  sdkconfig: {sdkconfig_h}')
     return 0
 
 

--- a/scripts/gen-esp32s3-cross.py
+++ b/scripts/gen-esp32s3-cross.py
@@ -95,6 +95,8 @@ def main():
     for p in all_includes:
         if any(d in p for d in project_src_dirs):
             continue
+        if not os.path.isabs(p):
+            p = os.path.normpath(os.path.join(idf_build_dir, p))
         idf_includes.append(p)
 
     """ Architecture and compiler flags (Xtensa LX7) """

--- a/scripts/pio_meson_bridge.py
+++ b/scripts/pio_meson_bridge.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+#
+# PlatformIO Meson bridge helper.
+#
+# Called by the CMake RTCLAW_PLATFORMIO branch to:
+#   1. Generate Meson cross-file from PlatformIO compile_commands.json
+#   2. Validate four-way IDF/compiler consistency
+#   3. Detect and handle stale Meson compiler state
+#   4. Run meson compile (incremental)
+
+import configparser
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+
+def fail(msg):
+    sys.stderr.write(f"[pio_meson_bridge] Error: {msg}\n")
+    sys.exit(1)
+
+
+def info(msg):
+    print(f"[pio_meson_bridge] {msg}")
+
+
+def extract_cc_from_compile_commands(cc_json_path):
+    """Extract compiler path from compile_commands.json."""
+    if not os.path.exists(cc_json_path):
+        return None
+    with open(cc_json_path) as f:
+        entries = json.load(f)
+    for e in entries:
+        if "rt_claw_stub.c" in e.get("file", ""):
+            return e["command"].split()[0]
+    for e in entries:
+        cmd = e.get("command", "")
+        if cmd:
+            return cmd.split()[0]
+    return None
+
+
+def extract_cc_from_cross_ini(cross_ini_path):
+    """Extract compiler path from generated Meson cross-file."""
+    if not os.path.exists(cross_ini_path):
+        return None
+    cp = configparser.ConfigParser()
+    cp.read(cross_ini_path)
+    if cp.has_option("binaries", "c"):
+        return cp.get("binaries", "c").strip("'\"")
+    return None
+
+
+def extract_cc_from_meson_introspection(meson_build_dir):
+    """Extract the actual compiler Meson is configured with."""
+    intro = os.path.join(meson_build_dir, "meson-info",
+                         "intro-compilers.json")
+    if not os.path.exists(intro):
+        return None
+    with open(intro) as f:
+        data = json.load(f)
+    host = data.get("host", {})
+    c_info = host.get("c", {})
+    exelist = c_info.get("exelist", [])
+    return exelist[0] if exelist else None
+
+
+def normalize(path):
+    """Normalize a compiler path for comparison."""
+    if not path:
+        return None
+    return os.path.realpath(os.path.expanduser(path))
+
+
+def validate_consistency(idf_cc_json, cross_ini, meson_build_dir,
+                         framework_path):
+    """Four-way IDF consistency validation.
+
+    Compares compiler paths from:
+      (a) PlatformIO compile_commands.json
+      (b) Generated cross.ini
+      (c) Meson introspection (if exists)
+      (d) Framework path logged for reference
+    Fails on any mismatch.
+    """
+    info("Validating IDF/compiler consistency...")
+
+    cc_from_db = extract_cc_from_compile_commands(idf_cc_json)
+    cc_from_cross = extract_cc_from_cross_ini(cross_ini)
+    cc_from_meson = extract_cc_from_meson_introspection(meson_build_dir)
+
+    info(f"  Framework:         {framework_path}")
+    info(f"  compile_commands:  {cc_from_db}")
+    info(f"  cross.ini:         {cc_from_cross}")
+    info(f"  Meson introspect:  {cc_from_meson}")
+
+    norm_db = normalize(cc_from_db)
+    norm_cross = normalize(cc_from_cross)
+    norm_meson = normalize(cc_from_meson)
+
+    if norm_db and norm_cross and norm_db != norm_cross:
+        fail(f"Compiler mismatch!\n"
+             f"  compile_commands.json: {cc_from_db} -> {norm_db}\n"
+             f"  cross.ini:            {cc_from_cross} -> {norm_cross}")
+
+    stale = False
+    if norm_meson and norm_cross and norm_meson != norm_cross:
+        info(f"  Meson configured with different compiler:")
+        info(f"    Meson:  {norm_meson}")
+        info(f"    Cross:  {norm_cross}")
+        stale = True
+
+    info("  Consistency check passed")
+    return stale
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="PlatformIO Meson bridge helper")
+    parser.add_argument("--chip", required=True,
+                        choices=["esp32c3", "esp32s3"])
+    parser.add_argument("--board", required=True)
+    parser.add_argument("--idf-build-dir", required=True)
+    parser.add_argument("--board-build-dir", required=True)
+    parser.add_argument("--meson-build-dir", required=True)
+    parser.add_argument("--framework-path", default="")
+    args = parser.parse_args()
+
+    gen_cross = os.path.join(os.path.dirname(__file__),
+                             f"gen-{args.chip}-cross.py")
+    if not os.path.exists(gen_cross):
+        fail(f"gen-cross script not found: {gen_cross}")
+
+    cc_json = os.path.join(args.idf_build_dir, "compile_commands.json")
+    if not os.path.exists(cc_json):
+        fail(f"compile_commands.json not found at {cc_json}.\n"
+             f"  PlatformIO cmake configure may not have completed.")
+
+    info(f"Generating cross-file for {args.chip}-{args.board}...")
+    subprocess.check_call(
+        [sys.executable, gen_cross,
+         "--idf-build-dir", args.idf_build_dir,
+         "--board-build-dir", args.board_build_dir,
+         args.board])
+
+    cross_ini = os.path.join(args.board_build_dir, "cross.ini")
+
+    stale = validate_consistency(cc_json, cross_ini,
+                                 args.meson_build_dir,
+                                 args.framework_path)
+
+    if stale and os.path.isdir(args.meson_build_dir):
+        info("Removing stale Meson build directory...")
+        shutil.rmtree(args.meson_build_dir)
+
+    if not os.path.exists(os.path.join(args.meson_build_dir,
+                                       "build.ninja")):
+        info("Running meson setup...")
+        subprocess.check_call(
+            ["meson", "setup", args.meson_build_dir,
+             f"--cross-file={cross_ini}"],
+            cwd=os.path.dirname(os.path.dirname(__file__)))
+    else:
+        subprocess.check_call(
+            ["meson", "setup", "--reconfigure", args.meson_build_dir,
+             f"--cross-file={cross_ini}"],
+            cwd=os.path.dirname(os.path.dirname(__file__)))
+
+    info("Running meson compile...")
+    subprocess.check_call(
+        ["meson", "compile", "-C", args.meson_build_dir],
+        cwd=os.path.dirname(os.path.dirname(__file__)))
+
+    for lib in ["claw/librtclaw.a", "osal/libosal.a",
+                "vendor/lib/cjson/libcjson.a"]:
+        path = os.path.join(args.meson_build_dir, lib)
+        if not os.path.exists(path):
+            fail(f"Expected Meson archive missing: {path}")
+
+    info(f"Meson bridge complete for {args.chip}-{args.board}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pio_post_configure.py
+++ b/scripts/pio_post_configure.py
@@ -7,7 +7,6 @@
 # Invokes the Meson bridge helper, then injects Meson objects into
 # the firmware link via env.Append(LINKFLAGS=...).
 
-import glob
 import os
 import subprocess
 import sys
@@ -24,64 +23,70 @@ def _info(msg):
     print(f"[pio_post_configure] {msg}")
 
 
-build_targets = COMMAND_LINE_TARGETS or ["buildprog"]  # noqa: F821
-skip_targets = {"clean", "cleanall", "idedata", "menuconfig"}
-if any(t in skip_targets for t in build_targets):
+if env.IsIntegrationDump():
     pass
 else:
-    board = env.GetProjectOption("custom_rtclaw_board", None)
-    if not board:
-        _fail("custom_rtclaw_board not set")
+    build_targets = COMMAND_LINE_TARGETS or ["buildprog"]  # noqa: F821
+    skip_targets = {"clean", "cleanall", "idedata", "menuconfig"}
+    if any(t in skip_targets for t in build_targets):
+        pass
+    else:
+        board = env.GetProjectOption("custom_rtclaw_board", None)
+        if not board:
+            _fail("custom_rtclaw_board not set")
 
-    pio_board = env.BoardConfig()
-    mcu = pio_board.get("build.mcu", "esp32c3")
-    chip = "esp32s3" if ("esp32s3" in mcu or "esp32-s3" in mcu) else "esp32c3"
+        pio_board = env.BoardConfig()
+        mcu = pio_board.get("build.mcu", "esp32c3")
+        chip = ("esp32s3" if ("esp32s3" in mcu or "esp32-s3" in mcu)
+                else "esp32c3")
 
-    project_dir = env.subst("$PROJECT_DIR")
-    project_root = os.path.dirname(os.path.dirname(project_dir))
-    build_dir = env.subst("$BUILD_DIR")
-    board_build_dir = os.path.join(project_root, "build",
-                                   f"{chip}-{board}")
-    meson_build_dir = os.path.join(board_build_dir, "meson")
+        project_dir = env.subst("$PROJECT_DIR")
+        project_root = os.path.dirname(os.path.dirname(project_dir))
+        build_dir = env.subst("$BUILD_DIR")
+        board_build_dir = os.path.join(project_root, "build",
+                                       f"{chip}-{board}")
+        meson_build_dir = os.path.join(board_build_dir, "meson")
 
-    cc_json = os.path.join(build_dir, "compile_commands.json")
-    if not os.path.exists(cc_json):
-        _fail(f"compile_commands.json not found at {cc_json}")
+        cc_json = os.path.join(build_dir, "compile_commands.json")
+        if not os.path.exists(cc_json):
+            _fail(f"compile_commands.json not found at {cc_json}")
 
-    bridge = os.path.join(project_root, "scripts", "pio_meson_bridge.py")
+        bridge = os.path.join(project_root, "scripts",
+                              "pio_meson_bridge.py")
 
-    platform_obj = env.PioPlatform()
-    framework_dir = platform_obj.get_package_dir("framework-espidf") or ""
+        platform_obj = env.PioPlatform()
+        framework_dir = (platform_obj.get_package_dir("framework-espidf")
+                         or "")
 
-    _info(f"Running Meson bridge for {chip}-{board}...")
-    rc = subprocess.call(
-        [sys.executable, bridge,
-         "--chip", chip,
-         "--board", board,
-         "--idf-build-dir", build_dir,
-         "--board-build-dir", board_build_dir,
-         "--meson-build-dir", meson_build_dir,
-         "--framework-path", framework_dir],
-        cwd=project_root)
-    if rc != 0:
-        _fail("pio_meson_bridge.py failed")
+        _info(f"Running Meson bridge for {chip}-{board}...")
+        rc = subprocess.call(
+            [sys.executable, bridge,
+             "--chip", chip,
+             "--board", board,
+             "--idf-build-dir", build_dir,
+             "--board-build-dir", board_build_dir,
+             "--meson-build-dir", meson_build_dir,
+             "--framework-path", framework_dir],
+            cwd=project_root)
+        if rc != 0:
+            _fail("pio_meson_bridge.py failed")
 
-    meson_objs = []
-    for subdir in ["claw/librtclaw.a.p",
-                    "osal/libosal.a.p",
-                    "vendor/lib/cjson/libcjson.a.p"]:
-        d = os.path.join(meson_build_dir, subdir)
-        if os.path.isdir(d):
-            meson_objs.extend(
-                os.path.join(d, f) for f in os.listdir(d)
-                if f.endswith(".o")
-            )
-    if not meson_objs:
-        _fail(f"No Meson objects in {meson_build_dir}")
+        meson_objs = []
+        for subdir in ["claw/librtclaw.a.p",
+                        "osal/libosal.a.p",
+                        "vendor/lib/cjson/libcjson.a.p"]:
+            d = os.path.join(meson_build_dir, subdir)
+            if os.path.isdir(d):
+                meson_objs.extend(
+                    os.path.join(d, f) for f in os.listdir(d)
+                    if f.endswith(".o")
+                )
+        if not meson_objs:
+            _fail(f"No Meson objects in {meson_build_dir}")
 
-    env.Append(
-        LINKFLAGS=["-Wl,--whole-archive"] +
-                  meson_objs +
-                  ["-Wl,--no-whole-archive"]
-    )
-    _info(f"Injected {len(meson_objs)} Meson objects into firmware link")
+        env.Append(
+            LINKFLAGS=["-Wl,--whole-archive"] +
+                      meson_objs +
+                      ["-Wl,--no-whole-archive"]
+        )
+        _info(f"Injected {len(meson_objs)} Meson objects into firmware link")

--- a/scripts/pio_post_configure.py
+++ b/scripts/pio_post_configure.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+#
+# PlatformIO post-configure script for rt-claw.
+#
+# Runs AFTER ESP-IDF cmake configure (so compile_commands.json exists).
+# Invokes the Meson bridge helper, then injects Meson objects into
+# the firmware link via env.Append(LINKFLAGS=...).
+
+import glob
+import os
+import subprocess
+import sys
+
+Import("env")  # noqa: F821  PlatformIO SCons global
+
+
+def _fail(msg):
+    sys.stderr.write(f"[pio_post_configure] Error: {msg}\n")
+    env.Exit(1)
+
+
+def _info(msg):
+    print(f"[pio_post_configure] {msg}")
+
+
+build_targets = COMMAND_LINE_TARGETS or ["buildprog"]  # noqa: F821
+skip_targets = {"clean", "cleanall", "idedata", "menuconfig"}
+if any(t in skip_targets for t in build_targets):
+    pass
+else:
+    board = env.GetProjectOption("custom_rtclaw_board", None)
+    if not board:
+        _fail("custom_rtclaw_board not set")
+
+    pio_board = env.BoardConfig()
+    mcu = pio_board.get("build.mcu", "esp32c3")
+    chip = "esp32s3" if ("esp32s3" in mcu or "esp32-s3" in mcu) else "esp32c3"
+
+    project_dir = env.subst("$PROJECT_DIR")
+    project_root = os.path.dirname(os.path.dirname(project_dir))
+    build_dir = env.subst("$BUILD_DIR")
+    board_build_dir = os.path.join(project_root, "build",
+                                   f"{chip}-{board}")
+    meson_build_dir = os.path.join(board_build_dir, "meson")
+
+    cc_json = os.path.join(build_dir, "compile_commands.json")
+    if not os.path.exists(cc_json):
+        _fail(f"compile_commands.json not found at {cc_json}")
+
+    bridge = os.path.join(project_root, "scripts", "pio_meson_bridge.py")
+
+    platform_obj = env.PioPlatform()
+    framework_dir = platform_obj.get_package_dir("framework-espidf") or ""
+
+    _info(f"Running Meson bridge for {chip}-{board}...")
+    rc = subprocess.call(
+        [sys.executable, bridge,
+         "--chip", chip,
+         "--board", board,
+         "--idf-build-dir", build_dir,
+         "--board-build-dir", board_build_dir,
+         "--meson-build-dir", meson_build_dir,
+         "--framework-path", framework_dir],
+        cwd=project_root)
+    if rc != 0:
+        _fail("pio_meson_bridge.py failed")
+
+    meson_objs = []
+    for subdir in ["claw/librtclaw.a.p",
+                    "osal/libosal.a.p",
+                    "vendor/lib/cjson/libcjson.a.p"]:
+        d = os.path.join(meson_build_dir, subdir)
+        if os.path.isdir(d):
+            meson_objs.extend(
+                os.path.join(d, f) for f in os.listdir(d)
+                if f.endswith(".o")
+            )
+    if not meson_objs:
+        _fail(f"No Meson objects in {meson_build_dir}")
+
+    env.Append(
+        LINKFLAGS=["-Wl,--whole-archive"] +
+                  meson_objs +
+                  ["-Wl,--no-whole-archive"]
+    )
+    _info(f"Injected {len(meson_objs)} Meson objects into firmware link")

--- a/scripts/pio_pre_build.py
+++ b/scripts/pio_pre_build.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+#
+# PlatformIO pre-build script for rt-claw.
+#
+# Orchestrates the existing Meson + ESP-IDF build chain so that
+# pio run produces a flashable firmware without manual toolchain
+# setup.  Runs as a pre:extra_script in platformio.ini.
+
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+
+Import("env")  # noqa: F821  PlatformIO SCons global
+
+
+def _fail(msg):
+    sys.stderr.write(f"[pio_pre_build] Error: {msg}\n")
+    env.Exit(1)
+
+
+def _info(msg):
+    print(f"[pio_pre_build] {msg}")
+
+
+def _check_tool(name):
+    if shutil.which(name) is None:
+        _fail(f"'{name}' not found. Install it:\n"
+              f"  pip install {name}" if name == "meson" else
+              f"  apt install ninja-build  (or pip install ninja)")
+
+
+def _resolve_idf_path():
+    """Return the ESP-IDF root from PlatformIO's framework-espidf package."""
+    platform = env.PioPlatform()
+    framework_dir = platform.get_package_dir("framework-espidf")
+    if not framework_dir or not os.path.isdir(framework_dir):
+        _fail("framework-espidf package not found in PlatformIO")
+    return framework_dir
+
+
+def _hash_files(paths):
+    """Compute a combined sha256 over a list of file paths."""
+    h = hashlib.sha256()
+    for p in sorted(paths):
+        if os.path.exists(p):
+            with open(p, "rb") as f:
+                h.update(f.read())
+    return h.hexdigest()
+
+
+def _stamp_changed(stamp_path, current_hash):
+    if not os.path.exists(stamp_path):
+        return True
+    with open(stamp_path) as f:
+        return f.read().strip() != current_hash
+
+
+def _write_stamp(stamp_path, current_hash):
+    os.makedirs(os.path.dirname(stamp_path), exist_ok=True)
+    with open(stamp_path, "w") as f:
+        f.write(current_hash)
+
+
+def pre_build(source, target, env):
+    build_type = env.GetBuildType()
+    if build_type in ("clean", "cleanall"):
+        _info("Skipping Meson chain for clean target")
+        return
+
+    _check_tool("meson")
+    _check_tool("ninja")
+
+    board = env.GetProjectOption("custom_rtclaw_board", None)
+    if not board:
+        _fail("custom_rtclaw_board not set in platformio.ini environment")
+
+    pio_board = env.BoardConfig()
+    mcu = pio_board.get("build.mcu", "esp32c3")
+    if "esp32s3" in mcu or "esp32-s3" in mcu:
+        chip = "esp32s3"
+    else:
+        chip = "esp32c3"
+
+    idf_path = _resolve_idf_path()
+    idf_py = os.path.join(idf_path, "tools", "idf.py")
+    if not os.path.exists(idf_py):
+        _fail(f"idf.py not found at {idf_py}")
+
+    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    board_build_dir = os.path.join(project_root, "build",
+                                   f"{chip}-{board}")
+    idf_build_dir = os.path.join(board_build_dir, "idf")
+    meson_build_dir = os.path.join(board_build_dir, "meson")
+
+    platform_dir = os.path.join(project_root, "platform", chip)
+    sdkconfig_defaults = os.path.join(platform_dir, "boards", board,
+                                      "sdkconfig.defaults")
+
+    stamp_path = os.path.join(board_build_dir, ".pio_stamp")
+    hash_inputs = [
+        sdkconfig_defaults,
+        os.path.join(project_root, "meson.build"),
+        os.path.join(project_root, "meson_options.txt"),
+        os.path.join(project_root, "claw_config.h"),
+    ]
+    current_hash = _hash_files(hash_inputs)
+    needs_reconfigure = _stamp_changed(stamp_path, current_hash)
+
+    cc_json = os.path.join(idf_build_dir, "compile_commands.json")
+    idf_env = os.environ.copy()
+    idf_env["IDF_PATH"] = idf_path
+
+    if not os.path.exists(cc_json) or needs_reconfigure:
+        _info(f"Configuring IDF for {chip}-{board}...")
+        subprocess.check_call(
+            [sys.executable, idf_py,
+             "-B", idf_build_dir,
+             f"-DRTCLAW_BOARD={board}",
+             "set-target", chip],
+            cwd=platform_dir, env=idf_env)
+        subprocess.check_call(
+            [sys.executable, idf_py,
+             "-B", idf_build_dir,
+             f"-DRTCLAW_BOARD={board}",
+             "reconfigure"],
+            cwd=platform_dir, env=idf_env)
+
+    gen_cross = os.path.join(project_root, "scripts",
+                             f"gen-{chip}-cross.py")
+    _info(f"Generating Meson cross-file for {board}...")
+    subprocess.check_call(
+        [sys.executable, gen_cross,
+         "--idf-build-dir", idf_build_dir,
+         "--board-build-dir", board_build_dir,
+         board],
+        cwd=project_root, env=idf_env)
+
+    cross_ini = os.path.join(board_build_dir, "cross.ini")
+    build_ninja = os.path.join(meson_build_dir, "build.ninja")
+    if not os.path.exists(build_ninja):
+        _info("Running meson setup...")
+        subprocess.check_call(
+            ["meson", "setup", meson_build_dir,
+             f"--cross-file={cross_ini}"],
+            cwd=project_root)
+    elif needs_reconfigure:
+        _info("Running meson setup --reconfigure...")
+        subprocess.check_call(
+            ["meson", "setup", "--reconfigure", meson_build_dir,
+             f"--cross-file={cross_ini}"],
+            cwd=project_root)
+
+    _info("Running meson compile...")
+    subprocess.check_call(
+        ["meson", "compile", "-C", meson_build_dir],
+        cwd=project_root)
+
+    _write_stamp(stamp_path, current_hash)
+
+    env.Append(CPPDEFINES=[
+        ("RTCLAW_BOARD", f'\\"{board}\\"'),
+    ])
+
+    _info(f"Meson build complete for {chip}-{board}")
+
+
+env.AddPreAction("buildprog", pre_build)

--- a/scripts/pio_pre_build.py
+++ b/scripts/pio_pre_build.py
@@ -3,11 +3,15 @@
 #
 # PlatformIO pre-build script for rt-claw.
 #
-# Orchestrates the existing Meson + ESP-IDF build chain so that
-# pio run produces a flashable firmware without manual toolchain
-# setup.  Runs as a pre:extra_script in platformio.ini.
+# Orchestrates the Meson build chain by deriving toolchain paths
+# from PlatformIO's package manager, then running meson compile
+# to produce claw/osal objects.  The CMake POST_BUILD step in
+# components/rt_claw/ merges these objects into the firmware.
 
+import configparser
 import hashlib
+import io
+import json
 import os
 import shutil
 import subprocess
@@ -27,22 +31,14 @@ def _info(msg):
 
 def _check_tool(name):
     if shutil.which(name) is None:
-        _fail(f"'{name}' not found. Install it:\n"
-              f"  pip install {name}" if name == "meson" else
-              f"  apt install ninja-build  (or pip install ninja)")
-
-
-def _resolve_idf_path():
-    """Return the ESP-IDF root from PlatformIO's framework-espidf package."""
-    platform = env.PioPlatform()
-    framework_dir = platform.get_package_dir("framework-espidf")
-    if not framework_dir or not os.path.isdir(framework_dir):
-        _fail("framework-espidf package not found in PlatformIO")
-    return framework_dir
+        if name == "meson":
+            hint = "  pip install meson"
+        else:
+            hint = "  apt install ninja-build  (or pip install ninja)"
+        _fail(f"'{name}' not found. Install it:\n{hint}")
 
 
 def _hash_files(paths):
-    """Compute a combined sha256 over a list of file paths."""
     h = hashlib.sha256()
     for p in sorted(paths):
         if os.path.exists(p):
@@ -64,10 +60,220 @@ def _write_stamp(stamp_path, current_hash):
         f.write(current_hash)
 
 
-def pre_build(source, target, env):
-    build_type = env.GetBuildType()
-    if build_type in ("clean", "cleanall"):
-        _info("Skipping Meson chain for clean target")
+def _resolve_compiler(platform_obj, chip):
+    """Get compiler path from PlatformIO's installed toolchain."""
+    if chip == "esp32c3":
+        pkg = "toolchain-riscv32-esp"
+        prefix = "riscv32-esp-elf"
+    else:
+        pkg = "toolchain-xtensa-esp-elf"
+        prefix = "xtensa-esp32s3-elf"
+    pkg_dir = platform_obj.get_package_dir(pkg)
+    if not pkg_dir:
+        _fail(f"Toolchain package '{pkg}' not found")
+    compiler = os.path.join(pkg_dir, "bin", f"{prefix}-gcc")
+    if not os.path.exists(compiler):
+        _fail(f"Compiler not found: {compiler}")
+    return compiler
+
+
+def _resolve_idf_path(platform_obj):
+    framework_dir = platform_obj.get_package_dir("framework-espidf")
+    if not framework_dir or not os.path.isdir(framework_dir):
+        _fail("framework-espidf package not found in PlatformIO")
+    return framework_dir
+
+
+def _generate_cross_file(cross_ini, compiler, chip, board,
+                         idf_path, sdkconfig_h):
+    """Generate Meson cross-file from PlatformIO toolchain info."""
+    ar = compiler.replace("-gcc", "-ar")
+    strip_bin = compiler.replace("-gcc", "-strip")
+
+    if chip == "esp32c3":
+        cpu_family = "riscv32"
+        cpu = "esp32c3"
+        arch_flags = [
+            "-march=rv32imc_zicsr_zifencei",
+            "-ffunction-sections",
+            "-fdata-sections",
+            "-fno-jump-tables",
+            "-fno-tree-switch-conversion",
+            "-fdiagnostics-color=always",
+        ]
+    else:
+        cpu_family = "xtensa"
+        cpu = "esp32s3"
+        arch_flags = [
+            "-mlongcalls",
+            "-ffunction-sections",
+            "-fdata-sections",
+            "-fstrict-volatile-bitfields",
+            "-fdiagnostics-color=always",
+        ]
+
+    c_args = list(arch_flags)
+
+    if sdkconfig_h and os.path.exists(sdkconfig_h):
+        c_args.extend(["-include", sdkconfig_h])
+
+    c_args.extend([
+        "-DCLAW_PLATFORM_ESP_IDF",
+        "-DESP_PLATFORM",
+        "-D_GNU_SOURCE",
+        "-D_POSIX_READER_WRITER_LOCKS",
+    ])
+
+    idf_inc_dirs = [
+        "components/freertos/FreeRTOS-Kernel/include",
+        "components/freertos/FreeRTOS-Kernel/portable/riscv/include"
+        if chip == "esp32c3" else
+        "components/freertos/FreeRTOS-Kernel/portable/xtensa/include",
+        "components/freertos/config/include",
+        "components/freertos/config/include/freertos",
+        "components/freertos/config/riscv/include"
+        if chip == "esp32c3" else
+        "components/freertos/config/xtensa/include",
+        "components/esp_common/include",
+        "components/esp_hw_support/include",
+        "components/esp_system/include",
+        "components/esp_rom/include",
+        f"components/esp_rom/{chip}/include",
+        "components/hal/include",
+        f"components/hal/{chip}/include",
+        "components/soc/include",
+        f"components/soc/{chip}/include",
+        f"components/soc/{chip}/register",
+        "components/heap/include",
+        "components/log/include",
+        "components/newlib/platform_include",
+        "components/esp_timer/include",
+        "components/esp_event/include",
+        "components/esp_netif/include",
+        "components/esp_wifi/include",
+        "components/esp_eth/include",
+        "components/lwip/include",
+        "components/lwip/lwip/src/include",
+        "components/lwip/port/include",
+        "components/esp_http_client/include",
+        "components/esp_websocket_client/include",
+        "components/json/cJSON",
+        "components/nvs_flash/include",
+        "components/esp-tls/include",
+        "components/esp_driver_gpio/include",
+        "components/driver/deprecated",
+        "components/esp_lcd/include",
+        "components/esp_driver_i2c/include",
+        "components/esp_driver_i2s/include",
+        "components/app_update/include",
+        "components/esp_http_server/include",
+        "components/riscv/include" if chip == "esp32c3"
+        else "components/xtensa/include",
+        "components/esp_partition/include",
+        "components/spi_flash/include",
+        "components/bootloader_support/include",
+    ]
+
+    for d in idf_inc_dirs:
+        full = os.path.join(idf_path, d)
+        if os.path.isdir(full):
+            c_args.extend(["-isystem", full])
+
+    kconfig_to_meson = {
+        "CONFIG_RTCLAW_SWARM_ENABLE": "swarm",
+        "CONFIG_RTCLAW_SCHED_ENABLE": "sched",
+        "CONFIG_RTCLAW_SKILL_ENABLE": "skill",
+        "CONFIG_RTCLAW_TOOL_GPIO": "tool_gpio",
+        "CONFIG_RTCLAW_TOOL_SYSTEM": "tool_system",
+        "CONFIG_RTCLAW_TOOL_SCHED": "tool_sched",
+        "CONFIG_RTCLAW_TOOL_NET": "tool_net",
+        "CONFIG_RTCLAW_TOOL_MOUSE": "tool_mouse",
+        "CONFIG_RTCLAW_HEARTBEAT_ENABLE": "heartbeat",
+        "CONFIG_RTCLAW_FEISHU_ENABLE": "feishu",
+        "CONFIG_RTCLAW_TELEGRAM_ENABLE": "telegram",
+        "CONFIG_RTCLAW_OTA_ENABLE": "ota",
+    }
+    enabled = set()
+    if sdkconfig_h and os.path.exists(sdkconfig_h):
+        with open(sdkconfig_h) as sh:
+            for line in sh:
+                for kconf in kconfig_to_meson:
+                    if f"#define {kconf} " in line or \
+                       f"#define {kconf}\n" in line:
+                        enabled.add(kconf)
+
+    buf = io.StringIO()
+    buf.write(f"# Auto-generated Meson cross-file for {chip.upper()} "
+              f"(PlatformIO)\n")
+    buf.write(f"# Board: {board}\n")
+    buf.write("# DO NOT edit manually or commit to git.\n\n")
+    buf.write("[binaries]\n")
+    buf.write(f"c = '{compiler}'\n")
+    buf.write(f"ar = '{ar}'\n")
+    buf.write(f"strip = '{strip_bin}'\n\n")
+    buf.write("[host_machine]\n")
+    buf.write("system = 'none'\n")
+    buf.write(f"cpu_family = '{cpu_family}'\n")
+    buf.write(f"cpu = '{cpu}'\n")
+    buf.write("endian = 'little'\n\n")
+    buf.write("[built-in options]\n")
+    args_str = ", ".join(f"'{a}'" for a in c_args)
+    buf.write(f"c_args = [{args_str}]\n")
+    buf.write("b_staticpic = false\n")
+    buf.write("b_pie = false\n\n")
+    buf.write("[project options]\n")
+    buf.write("osal = 'freertos'\n")
+    for kconf, mopt in kconfig_to_meson.items():
+        val = "true" if kconf in enabled else "false"
+        buf.write(f"{mopt} = {val}\n")
+
+    new_content = buf.getvalue()
+    old_content = ""
+    if os.path.exists(cross_ini):
+        with open(cross_ini) as existing:
+            old_content = existing.read()
+
+    os.makedirs(os.path.dirname(cross_ini), exist_ok=True)
+    if new_content != old_content:
+        with open(cross_ini, "w") as out:
+            out.write(new_content)
+        return True
+    return False
+
+
+def _validate_idf_consistency(idf_path, compiler, cross_ini):
+    """Verify compiler consistency between PlatformIO toolchain and
+    generated cross-file (AC-4)."""
+    _info("Validating IDF path consistency...")
+
+    cp = configparser.ConfigParser()
+    cp.read(cross_ini)
+    cross_compiler = None
+    if cp.has_option("binaries", "c"):
+        cross_compiler = cp.get("binaries", "c").strip("'\"")
+
+    _info(f"  Framework path:   {idf_path}")
+    _info(f"  PIO compiler:     {compiler}")
+    _info(f"  Cross compiler:   {cross_compiler}")
+
+    if cross_compiler:
+        pio_base = os.path.basename(compiler)
+        cross_base = os.path.basename(cross_compiler)
+        if pio_base != cross_base:
+            _fail(
+                f"IDF consistency check failed!\n"
+                f"  PlatformIO compiler: {compiler}\n"
+                f"  Cross-file compiler: {cross_compiler}\n"
+                f"  These must use the same toolchain.")
+
+    _info("  IDF consistency check passed")
+
+
+def pre_build():
+    build_targets = COMMAND_LINE_TARGETS or ["buildprog"]  # noqa: F821
+    skip_targets = {"clean", "cleanall", "idedata", "menuconfig"}
+    if any(t in skip_targets for t in build_targets):
+        _info(f"Skipping Meson chain for {build_targets}")
         return
 
     _check_tool("meson")
@@ -84,22 +290,25 @@ def pre_build(source, target, env):
     else:
         chip = "esp32c3"
 
-    idf_path = _resolve_idf_path()
-    idf_py = os.path.join(idf_path, "tools", "idf.py")
-    if not os.path.exists(idf_py):
-        _fail(f"idf.py not found at {idf_py}")
+    platform_obj = env.PioPlatform()
+    idf_path = _resolve_idf_path(platform_obj)
+    compiler = _resolve_compiler(platform_obj, chip)
 
-    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    project_dir = env.subst("$PROJECT_DIR")
+    project_root = os.path.dirname(os.path.dirname(project_dir))
     board_build_dir = os.path.join(project_root, "build",
                                    f"{chip}-{board}")
-    idf_build_dir = os.path.join(board_build_dir, "idf")
     meson_build_dir = os.path.join(board_build_dir, "meson")
 
-    platform_dir = os.path.join(project_root, "platform", chip)
-    sdkconfig_defaults = os.path.join(platform_dir, "boards", board,
-                                      "sdkconfig.defaults")
+    pio_build_dir = os.path.join(project_dir, ".pio", "build",
+                                 env.subst("$PIOENV"))
+    sdkconfig_h = os.path.join(pio_build_dir, "config", "sdkconfig.h")
+    if not os.path.exists(sdkconfig_h):
+        sdkconfig_h = None
 
     stamp_path = os.path.join(board_build_dir, ".pio_stamp")
+    sdkconfig_defaults = os.path.join(project_dir, "boards", board,
+                                      "sdkconfig.defaults")
     hash_inputs = [
         sdkconfig_defaults,
         os.path.join(project_root, "meson.build"),
@@ -109,36 +318,13 @@ def pre_build(source, target, env):
     current_hash = _hash_files(hash_inputs)
     needs_reconfigure = _stamp_changed(stamp_path, current_hash)
 
-    cc_json = os.path.join(idf_build_dir, "compile_commands.json")
-    idf_env = os.environ.copy()
-    idf_env["IDF_PATH"] = idf_path
-
-    if not os.path.exists(cc_json) or needs_reconfigure:
-        _info(f"Configuring IDF for {chip}-{board}...")
-        subprocess.check_call(
-            [sys.executable, idf_py,
-             "-B", idf_build_dir,
-             f"-DRTCLAW_BOARD={board}",
-             "set-target", chip],
-            cwd=platform_dir, env=idf_env)
-        subprocess.check_call(
-            [sys.executable, idf_py,
-             "-B", idf_build_dir,
-             f"-DRTCLAW_BOARD={board}",
-             "reconfigure"],
-            cwd=platform_dir, env=idf_env)
-
-    gen_cross = os.path.join(project_root, "scripts",
-                             f"gen-{chip}-cross.py")
-    _info(f"Generating Meson cross-file for {board}...")
-    subprocess.check_call(
-        [sys.executable, gen_cross,
-         "--idf-build-dir", idf_build_dir,
-         "--board-build-dir", board_build_dir,
-         board],
-        cwd=project_root, env=idf_env)
-
     cross_ini = os.path.join(board_build_dir, "cross.ini")
+    _info(f"Generating Meson cross-file for {chip}-{board}...")
+    changed = _generate_cross_file(cross_ini, compiler, chip, board,
+                                   idf_path, sdkconfig_h)
+
+    _validate_idf_consistency(idf_path, compiler, cross_ini)
+
     build_ninja = os.path.join(meson_build_dir, "build.ninja")
     if not os.path.exists(build_ninja):
         _info("Running meson setup...")
@@ -146,7 +332,7 @@ def pre_build(source, target, env):
             ["meson", "setup", meson_build_dir,
              f"--cross-file={cross_ini}"],
             cwd=project_root)
-    elif needs_reconfigure:
+    elif needs_reconfigure or changed:
         _info("Running meson setup --reconfigure...")
         subprocess.check_call(
             ["meson", "setup", "--reconfigure", meson_build_dir,
@@ -160,11 +346,26 @@ def pre_build(source, target, env):
 
     _write_stamp(stamp_path, current_hash)
 
-    env.Append(CPPDEFINES=[
-        ("RTCLAW_BOARD", f'\\"{board}\\"'),
-    ])
+    import glob
+    meson_objs = (
+        glob.glob(os.path.join(meson_build_dir,
+                               "claw", "librtclaw.a.p", "*.o")) +
+        glob.glob(os.path.join(meson_build_dir,
+                               "osal", "libosal.a.p", "*.o")) +
+        glob.glob(os.path.join(meson_build_dir,
+                               "vendor", "lib", "cjson",
+                               "libcjson.a.p", "*.o"))
+    )
+    if not meson_objs:
+        _fail(f"No Meson objects found in {meson_build_dir}")
 
-    _info(f"Meson build complete for {chip}-{board}")
+    env.Append(
+        LINKFLAGS=["-Wl,--whole-archive"] +
+                  meson_objs +
+                  ["-Wl,--no-whole-archive"]
+    )
+    _info(f"Meson build complete for {chip}-{board} "
+          f"({len(meson_objs)} objects injected)")
 
 
-env.AddPreAction("buildprog", pre_build)
+pre_build()

--- a/scripts/pio_pre_build.py
+++ b/scripts/pio_pre_build.py
@@ -3,18 +3,12 @@
 #
 # PlatformIO pre-build script for rt-claw.
 #
-# Orchestrates the Meson build chain by deriving toolchain paths
-# from PlatformIO's package manager, then running meson compile
-# to produce claw/osal objects.  The CMake POST_BUILD step in
-# components/rt_claw/ merges these objects into the firmware.
+# Sets CMake variables so the ESP-IDF component can orchestrate
+# the Meson build chain during cmake build phase (where
+# compile_commands.json is available).
 
-import configparser
-import hashlib
-import io
-import json
 import os
 import shutil
-import subprocess
 import sys
 
 Import("env")  # noqa: F821  PlatformIO SCons global
@@ -38,242 +32,11 @@ def _check_tool(name):
         _fail(f"'{name}' not found. Install it:\n{hint}")
 
 
-def _hash_files(paths):
-    h = hashlib.sha256()
-    for p in sorted(paths):
-        if os.path.exists(p):
-            with open(p, "rb") as f:
-                h.update(f.read())
-    return h.hexdigest()
-
-
-def _stamp_changed(stamp_path, current_hash):
-    if not os.path.exists(stamp_path):
-        return True
-    with open(stamp_path) as f:
-        return f.read().strip() != current_hash
-
-
-def _write_stamp(stamp_path, current_hash):
-    os.makedirs(os.path.dirname(stamp_path), exist_ok=True)
-    with open(stamp_path, "w") as f:
-        f.write(current_hash)
-
-
-def _resolve_compiler(platform_obj, chip):
-    """Get compiler path from PlatformIO's installed toolchain."""
-    if chip == "esp32c3":
-        pkg = "toolchain-riscv32-esp"
-        prefix = "riscv32-esp-elf"
-    else:
-        pkg = "toolchain-xtensa-esp-elf"
-        prefix = "xtensa-esp32s3-elf"
-    pkg_dir = platform_obj.get_package_dir(pkg)
-    if not pkg_dir:
-        _fail(f"Toolchain package '{pkg}' not found")
-    compiler = os.path.join(pkg_dir, "bin", f"{prefix}-gcc")
-    if not os.path.exists(compiler):
-        _fail(f"Compiler not found: {compiler}")
-    return compiler
-
-
-def _resolve_idf_path(platform_obj):
-    framework_dir = platform_obj.get_package_dir("framework-espidf")
-    if not framework_dir or not os.path.isdir(framework_dir):
-        _fail("framework-espidf package not found in PlatformIO")
-    return framework_dir
-
-
-def _generate_cross_file(cross_ini, compiler, chip, board,
-                         idf_path, sdkconfig_h):
-    """Generate Meson cross-file from PlatformIO toolchain info."""
-    ar = compiler.replace("-gcc", "-ar")
-    strip_bin = compiler.replace("-gcc", "-strip")
-
-    if chip == "esp32c3":
-        cpu_family = "riscv32"
-        cpu = "esp32c3"
-        arch_flags = [
-            "-march=rv32imc_zicsr_zifencei",
-            "-ffunction-sections",
-            "-fdata-sections",
-            "-fno-jump-tables",
-            "-fno-tree-switch-conversion",
-            "-fdiagnostics-color=always",
-        ]
-    else:
-        cpu_family = "xtensa"
-        cpu = "esp32s3"
-        arch_flags = [
-            "-mlongcalls",
-            "-ffunction-sections",
-            "-fdata-sections",
-            "-fstrict-volatile-bitfields",
-            "-fdiagnostics-color=always",
-        ]
-
-    c_args = list(arch_flags)
-
-    if sdkconfig_h and os.path.exists(sdkconfig_h):
-        c_args.extend(["-include", sdkconfig_h])
-
-    c_args.extend([
-        "-DCLAW_PLATFORM_ESP_IDF",
-        "-DESP_PLATFORM",
-        "-D_GNU_SOURCE",
-        "-D_POSIX_READER_WRITER_LOCKS",
-    ])
-
-    idf_inc_dirs = [
-        "components/freertos/FreeRTOS-Kernel/include",
-        "components/freertos/FreeRTOS-Kernel/portable/riscv/include"
-        if chip == "esp32c3" else
-        "components/freertos/FreeRTOS-Kernel/portable/xtensa/include",
-        "components/freertos/config/include",
-        "components/freertos/config/include/freertos",
-        "components/freertos/config/riscv/include"
-        if chip == "esp32c3" else
-        "components/freertos/config/xtensa/include",
-        "components/esp_common/include",
-        "components/esp_hw_support/include",
-        "components/esp_system/include",
-        "components/esp_rom/include",
-        f"components/esp_rom/{chip}/include",
-        "components/hal/include",
-        f"components/hal/{chip}/include",
-        "components/soc/include",
-        f"components/soc/{chip}/include",
-        f"components/soc/{chip}/register",
-        "components/heap/include",
-        "components/log/include",
-        "components/newlib/platform_include",
-        "components/esp_timer/include",
-        "components/esp_event/include",
-        "components/esp_netif/include",
-        "components/esp_wifi/include",
-        "components/esp_eth/include",
-        "components/lwip/include",
-        "components/lwip/lwip/src/include",
-        "components/lwip/port/include",
-        "components/esp_http_client/include",
-        "components/esp_websocket_client/include",
-        "components/json/cJSON",
-        "components/nvs_flash/include",
-        "components/esp-tls/include",
-        "components/esp_driver_gpio/include",
-        "components/driver/deprecated",
-        "components/esp_lcd/include",
-        "components/esp_driver_i2c/include",
-        "components/esp_driver_i2s/include",
-        "components/app_update/include",
-        "components/esp_http_server/include",
-        "components/riscv/include" if chip == "esp32c3"
-        else "components/xtensa/include",
-        "components/esp_partition/include",
-        "components/spi_flash/include",
-        "components/bootloader_support/include",
-    ]
-
-    for d in idf_inc_dirs:
-        full = os.path.join(idf_path, d)
-        if os.path.isdir(full):
-            c_args.extend(["-isystem", full])
-
-    kconfig_to_meson = {
-        "CONFIG_RTCLAW_SWARM_ENABLE": "swarm",
-        "CONFIG_RTCLAW_SCHED_ENABLE": "sched",
-        "CONFIG_RTCLAW_SKILL_ENABLE": "skill",
-        "CONFIG_RTCLAW_TOOL_GPIO": "tool_gpio",
-        "CONFIG_RTCLAW_TOOL_SYSTEM": "tool_system",
-        "CONFIG_RTCLAW_TOOL_SCHED": "tool_sched",
-        "CONFIG_RTCLAW_TOOL_NET": "tool_net",
-        "CONFIG_RTCLAW_TOOL_MOUSE": "tool_mouse",
-        "CONFIG_RTCLAW_HEARTBEAT_ENABLE": "heartbeat",
-        "CONFIG_RTCLAW_FEISHU_ENABLE": "feishu",
-        "CONFIG_RTCLAW_TELEGRAM_ENABLE": "telegram",
-        "CONFIG_RTCLAW_OTA_ENABLE": "ota",
-    }
-    enabled = set()
-    if sdkconfig_h and os.path.exists(sdkconfig_h):
-        with open(sdkconfig_h) as sh:
-            for line in sh:
-                for kconf in kconfig_to_meson:
-                    if f"#define {kconf} " in line or \
-                       f"#define {kconf}\n" in line:
-                        enabled.add(kconf)
-
-    buf = io.StringIO()
-    buf.write(f"# Auto-generated Meson cross-file for {chip.upper()} "
-              f"(PlatformIO)\n")
-    buf.write(f"# Board: {board}\n")
-    buf.write("# DO NOT edit manually or commit to git.\n\n")
-    buf.write("[binaries]\n")
-    buf.write(f"c = '{compiler}'\n")
-    buf.write(f"ar = '{ar}'\n")
-    buf.write(f"strip = '{strip_bin}'\n\n")
-    buf.write("[host_machine]\n")
-    buf.write("system = 'none'\n")
-    buf.write(f"cpu_family = '{cpu_family}'\n")
-    buf.write(f"cpu = '{cpu}'\n")
-    buf.write("endian = 'little'\n\n")
-    buf.write("[built-in options]\n")
-    args_str = ", ".join(f"'{a}'" for a in c_args)
-    buf.write(f"c_args = [{args_str}]\n")
-    buf.write("b_staticpic = false\n")
-    buf.write("b_pie = false\n\n")
-    buf.write("[project options]\n")
-    buf.write("osal = 'freertos'\n")
-    for kconf, mopt in kconfig_to_meson.items():
-        val = "true" if kconf in enabled else "false"
-        buf.write(f"{mopt} = {val}\n")
-
-    new_content = buf.getvalue()
-    old_content = ""
-    if os.path.exists(cross_ini):
-        with open(cross_ini) as existing:
-            old_content = existing.read()
-
-    os.makedirs(os.path.dirname(cross_ini), exist_ok=True)
-    if new_content != old_content:
-        with open(cross_ini, "w") as out:
-            out.write(new_content)
-        return True
-    return False
-
-
-def _validate_idf_consistency(idf_path, compiler, cross_ini):
-    """Verify compiler consistency between PlatformIO toolchain and
-    generated cross-file (AC-4)."""
-    _info("Validating IDF path consistency...")
-
-    cp = configparser.ConfigParser()
-    cp.read(cross_ini)
-    cross_compiler = None
-    if cp.has_option("binaries", "c"):
-        cross_compiler = cp.get("binaries", "c").strip("'\"")
-
-    _info(f"  Framework path:   {idf_path}")
-    _info(f"  PIO compiler:     {compiler}")
-    _info(f"  Cross compiler:   {cross_compiler}")
-
-    if cross_compiler:
-        pio_base = os.path.basename(compiler)
-        cross_base = os.path.basename(cross_compiler)
-        if pio_base != cross_base:
-            _fail(
-                f"IDF consistency check failed!\n"
-                f"  PlatformIO compiler: {compiler}\n"
-                f"  Cross-file compiler: {cross_compiler}\n"
-                f"  These must use the same toolchain.")
-
-    _info("  IDF consistency check passed")
-
-
 def pre_build():
     build_targets = COMMAND_LINE_TARGETS or ["buildprog"]  # noqa: F821
     skip_targets = {"clean", "cleanall", "idedata", "menuconfig"}
     if any(t in skip_targets for t in build_targets):
-        _info(f"Skipping Meson chain for {build_targets}")
+        _info(f"Skipping pre-build for {build_targets}")
         return
 
     _check_tool("meson")
@@ -290,82 +53,21 @@ def pre_build():
     else:
         chip = "esp32c3"
 
-    platform_obj = env.PioPlatform()
-    idf_path = _resolve_idf_path(platform_obj)
-    compiler = _resolve_compiler(platform_obj, chip)
-
     project_dir = env.subst("$PROJECT_DIR")
     project_root = os.path.dirname(os.path.dirname(project_dir))
-    board_build_dir = os.path.join(project_root, "build",
-                                   f"{chip}-{board}")
-    meson_build_dir = os.path.join(board_build_dir, "meson")
+    meson_build_dir = os.path.join(project_root, "build",
+                                   f"{chip}-{board}", "meson")
 
-    pio_build_dir = os.path.join(project_dir, ".pio", "build",
-                                 env.subst("$PIOENV"))
-    sdkconfig_h = os.path.join(pio_build_dir, "config", "sdkconfig.h")
-    if not os.path.exists(sdkconfig_h):
-        sdkconfig_h = None
+    cmake_extra = env.GetProjectOption("board_build.cmake_extra_args", "")
+    cmake_extra += (f" -DRTCLAW_MESON_BUILD_DIR={meson_build_dir}"
+                    f" -DRTCLAW_PLATFORMIO=1")
+    try:
+        pio_board.update("build.cmake_extra_args", cmake_extra)
+    except Exception:
+        pass
 
-    stamp_path = os.path.join(board_build_dir, ".pio_stamp")
-    sdkconfig_defaults = os.path.join(project_dir, "boards", board,
-                                      "sdkconfig.defaults")
-    hash_inputs = [
-        sdkconfig_defaults,
-        os.path.join(project_root, "meson.build"),
-        os.path.join(project_root, "meson_options.txt"),
-        os.path.join(project_root, "claw_config.h"),
-    ]
-    current_hash = _hash_files(hash_inputs)
-    needs_reconfigure = _stamp_changed(stamp_path, current_hash)
-
-    cross_ini = os.path.join(board_build_dir, "cross.ini")
-    _info(f"Generating Meson cross-file for {chip}-{board}...")
-    changed = _generate_cross_file(cross_ini, compiler, chip, board,
-                                   idf_path, sdkconfig_h)
-
-    _validate_idf_consistency(idf_path, compiler, cross_ini)
-
-    build_ninja = os.path.join(meson_build_dir, "build.ninja")
-    if not os.path.exists(build_ninja):
-        _info("Running meson setup...")
-        subprocess.check_call(
-            ["meson", "setup", meson_build_dir,
-             f"--cross-file={cross_ini}"],
-            cwd=project_root)
-    elif needs_reconfigure or changed:
-        _info("Running meson setup --reconfigure...")
-        subprocess.check_call(
-            ["meson", "setup", "--reconfigure", meson_build_dir,
-             f"--cross-file={cross_ini}"],
-            cwd=project_root)
-
-    _info("Running meson compile...")
-    subprocess.check_call(
-        ["meson", "compile", "-C", meson_build_dir],
-        cwd=project_root)
-
-    _write_stamp(stamp_path, current_hash)
-
-    import glob
-    meson_objs = (
-        glob.glob(os.path.join(meson_build_dir,
-                               "claw", "librtclaw.a.p", "*.o")) +
-        glob.glob(os.path.join(meson_build_dir,
-                               "osal", "libosal.a.p", "*.o")) +
-        glob.glob(os.path.join(meson_build_dir,
-                               "vendor", "lib", "cjson",
-                               "libcjson.a.p", "*.o"))
-    )
-    if not meson_objs:
-        _fail(f"No Meson objects found in {meson_build_dir}")
-
-    env.Append(
-        LINKFLAGS=["-Wl,--whole-archive"] +
-                  meson_objs +
-                  ["-Wl,--no-whole-archive"]
-    )
-    _info(f"Meson build complete for {chip}-{board} "
-          f"({len(meson_objs)} objects injected)")
+    _info(f"Pre-build: {chip}-{board}")
+    _info(f"  Meson build dir: {meson_build_dir}")
 
 
 pre_build()

--- a/scripts/pio_pre_build.py
+++ b/scripts/pio_pre_build.py
@@ -33,6 +33,9 @@ def _check_tool(name):
 
 
 def pre_build():
+    if env.IsIntegrationDump():
+        return
+
     build_targets = COMMAND_LINE_TARGETS or ["buildprog"]  # noqa: F821
     skip_targets = {"clean", "cleanall", "idedata", "menuconfig"}
     if any(t in skip_targets for t in build_targets):


### PR DESCRIPTION
## Summary

- Add PlatformIO as an alternative build system for ESP32-C3/S3
- PlatformIO uses bundled ESP-IDF (espressif32@6.10.0 = v5.4.0)
- Meson bridge helper validates compiler consistency and detects stale state
- gen-cross.py converted to argparse (backward compatible)
- Custom xiaozhi-xmini board JSON, bilingual docs, CI smoke workflow

## Test plan

- [x] pio run -e esp32c3_qemu — SUCCESS (19.4s)
- [x] pio run -e esp32c3_devkit — SUCCESS (18.3s)
- [x] pio run -e esp32c3_xiaozhi_xmini — SUCCESS (18.3s)
- [x] pio run -e esp32s3_qemu — SUCCESS (21.5s)
- [x] pio run -e esp32s3_default — SUCCESS (21.7s)
- [x] make build-esp32c3-qemu — SUCCESS
- [x] make build-linux — SUCCESS
- [x] make vexpress-a9-qemu — SUCCESS
- [x] make build-zynq-a9-qemu — SUCCESS
- [x] gen-esp32c3-cross.py --help — argparse works
- [ ] CI PlatformIO smoke job (pending)

Closes #113