### PR TITLE
drivers: fix wifi_manager_reconnect when STA is already disconnected

### DIFF
--- a/drivers/net/espressif/wifi_manager.c
+++ b/drivers/net/espressif/wifi_manager.c
@@ -244,8 +244,13 @@ esp_err_t wifi_manager_reconnect(const char *ssid, const char *password)
 
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_cfg));
     s_retry_count = 0;
-    esp_wifi_disconnect();
-
+    
+    if (s_connected) {
+        esp_wifi_disconnect();
+    } else {
+        esp_wifi_connect();
+    }
+    
     ESP_LOGI(TAG, "reconnecting to SSID: %s", ssid);
     return ESP_OK;
 }


### PR DESCRIPTION
After reboot with stale credentials, WiFi fails to connect and STA enters disconnected state. When /wifi_set then calls wifi_manager_reconnect, esp_wifi_disconnect() on an already- disconnected STA is a no-op and does not generate the WIFI_EVENT_STA_DISCONNECTED event. The event handler therefore never calls esp_wifi_connect(), leaving the new credentials unused.

Check the current STA state before deciding whether to trigger reconnection directly, so that new credentials take effect regardless of whether STA was already disconnected.

Signed-off-by: Jay_u <2422696024@qq.com>